### PR TITLE
`table.createViewModel`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelte-headless-table",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-headless-table",
-			"version": "0.4.1",
+			"version": "0.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"svelte-keyed": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-headless-table",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/src/lib/createTable.ts
+++ b/src/lib/createTable.ts
@@ -13,6 +13,7 @@ import {
 import type { AnyPlugins } from './types/TablePlugin';
 import type { ReadOrWritable } from './utils/store';
 import { getDuplicates } from './utils/array';
+import { createViewModel, type TableViewModel } from './createViewModel';
 
 export class Table<Item, Plugins extends AnyPlugins = AnyPlugins> {
 	data: ReadOrWritable<Item[]>;
@@ -49,6 +50,10 @@ export class Table<Item, Plugins extends AnyPlugins = AnyPlugins> {
 
 	group(def: GroupColumnInit<Item, Plugins>): GroupColumn<Item, Plugins> {
 		return new GroupColumn(def);
+	}
+
+	createViewModel(columns: Column<Item, Plugins>[]): TableViewModel<Item, Plugins> {
+		return createViewModel(this, columns);
 	}
 }
 

--- a/src/lib/createViewModel.ts
+++ b/src/lib/createViewModel.ts
@@ -12,7 +12,16 @@ import type {
 } from './types/TablePlugin';
 import { nonUndefined } from './utils/filter';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface TableViewModel<Item, Plugins extends AnyPlugins = AnyPlugins> {
+	dataColumns: DataColumn<Item, Plugins>[];
+	visibleColumns: Readable<DataColumn<Item, Plugins>[]>;
+	headerRows: Readable<HeaderRow<Item, Plugins>[]>;
+	originalRows: Readable<BodyRow<Item, Plugins>[]>;
+	rows: Readable<BodyRow<Item, Plugins>[]>;
+	pageRows: Readable<BodyRow<Item, Plugins>[]>;
+	pluginStates: PluginStates<Plugins>;
+}
+
 export interface TableState<Item, Plugins extends AnyPlugins = AnyPlugins> {
 	data: ReadOrWritable<Item[]>;
 	columns: Column<Item, Plugins>[];
@@ -23,10 +32,10 @@ export interface TableState<Item, Plugins extends AnyPlugins = AnyPlugins> {
 	pageRows: Readable<BodyRow<Item>[]>;
 }
 
-export const useTable = <Item, Plugins extends AnyPlugins = AnyPlugins>(
+export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	table: Table<Item, Plugins>,
 	columns: Column<Item, Plugins>[]
-) => {
+): TableViewModel<Item, Plugins> => {
 	const { data, plugins } = table;
 
 	const dataColumns = getDataColumns(columns);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,5 +3,4 @@ export { default as Render } from '$lib/components/Render.svelte';
 export { Subscribe } from 'svelte-subscribe';
 // table core
 export { createTable } from '$lib/createTable';
-export { useTable } from '$lib/useTable';
 export { createRender, type RenderConfig } from '$lib/render';

--- a/src/lib/plugins/useColumnFilters.ts
+++ b/src/lib/plugins/useColumnFilters.ts
@@ -3,7 +3,7 @@ import type { BodyRow } from '$lib/bodyRows';
 import type { TablePlugin, NewTablePropSet, DeriveRowsFn } from '$lib/types/TablePlugin';
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import type { RenderConfig } from '$lib/render';
-import type { TableState } from '$lib/useTable';
+import type { TableState } from '$lib/createViewModel';
 
 export interface ColumnFiltersState<Item> {
 	filterValues: Writable<Record<string, unknown>>;

--- a/src/lib/tableComponent.ts
+++ b/src/lib/tableComponent.ts
@@ -6,7 +6,7 @@ import type {
 	ElementHook,
 	PluginTablePropSet,
 } from './types/TablePlugin';
-import type { TableState } from './useTable';
+import type { TableState } from './createViewModel';
 
 export interface TableComponentInit {
 	id: string;

--- a/src/lib/types/Label.ts
+++ b/src/lib/types/Label.ts
@@ -1,4 +1,4 @@
-import type { TableState } from '$lib/useTable';
+import type { TableState } from '$lib/createViewModel';
 import type { RenderConfig } from '$lib/render';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/lib/types/TablePlugin.ts
+++ b/src/lib/types/TablePlugin.ts
@@ -3,7 +3,7 @@ import type { BodyRow, BodyRowAttributes } from '$lib/bodyRows';
 import type { DataColumn } from '$lib/columns';
 import type { HeaderCell, HeaderCellAttributes } from '$lib/headerCells';
 import type { HeaderRow, HeaderRowAttributes } from '$lib/headerRows';
-import type { TableState } from '$lib/useTable';
+import type { TableState } from '$lib/createViewModel';
 import type { Readable } from 'svelte/store';
 
 export type TablePlugin<Item, PluginState, ColumnOptions, TablePropSet extends AnyTablePropSet> = (

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { derived, readable } from 'svelte/store';
-	import { Render, Subscribe, createTable, createRender, useTable } from '$lib';
+	import { Render, Subscribe, createTable, createRender } from '$lib';
 	import {
 		useColumnFilters,
 		useColumnOrder,
@@ -134,7 +134,7 @@
 		}),
 	]);
 
-	const { visibleColumns, headerRows, rows, pageRows, pluginStates } = useTable(table, columns);
+	const { visibleColumns, headerRows, pageRows, pluginStates } = table.createViewModel(columns);
 
 	const { sortKeys } = pluginStates.sort;
 	const { filterValues } = pluginStates.filter;


### PR DESCRIPTION
Remove `useTable` for the more descriptive `Table#createViewModel` method name.