### PR TITLE
`addGridLayout`

### DIFF
--- a/src/lib/bodyCells.HeaderCell.render.test.ts
+++ b/src/lib/bodyCells.HeaderCell.render.test.ts
@@ -16,6 +16,7 @@ class TestHeaderCell<Item> extends HeaderCell<Item> {
 			id: this.id,
 			colspan: this.colspan,
 			label: this.label,
+			colstart: 1,
 		});
 	}
 }
@@ -25,6 +26,7 @@ it('renders string label', () => {
 		id: '0',
 		label: 'Name',
 		colspan: 1,
+		colstart: 1,
 	});
 
 	expect(actual.render()).toBe('Name');
@@ -39,6 +41,7 @@ it('renders dynamic label with state', () => {
 		id: '0',
 		label: ({ columns }) => `${columns.length} columns`,
 		colspan: 1,
+		colstart: 1,
 	});
 
 	actual.injectState(state);
@@ -51,6 +54,7 @@ it('throws if rendering dynamically without state', () => {
 		id: '0',
 		label: ({ columns }) => `${columns.length} columns`,
 		colspan: 1,
+		colstart: 1,
 	});
 
 	expect(() => {

--- a/src/lib/headerCells.ts
+++ b/src/lib/headerCells.ts
@@ -10,6 +10,7 @@ export type HeaderCellInit<Item, Plugins extends AnyPlugins = AnyPlugins> = {
 	id: string;
 	label: HeaderLabel<Item>;
 	colspan: number;
+	colstart: number;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -17,16 +18,19 @@ export type HeaderCellAttributes<Item, Plugins extends AnyPlugins = AnyPlugins> 
 	role: 'columnheader';
 	colspan: number;
 };
+
 export abstract class HeaderCell<
 	Item,
 	Plugins extends AnyPlugins = AnyPlugins
 > extends TableComponent<Item, Plugins, 'thead.tr.th'> {
 	label: HeaderLabel<Item>;
 	colspan: number;
-	constructor({ id, label, colspan }: HeaderCellInit<Item>) {
+	colstart: number;
+	constructor({ id, label, colspan, colstart }: HeaderCellInit<Item>) {
 		super({ id });
 		this.label = label;
 		this.colspan = colspan;
+		this.colstart = colstart;
 	}
 
 	render(): RenderConfig {
@@ -68,14 +72,15 @@ export class FlatHeaderCell<Item, Plugins extends AnyPlugins = AnyPlugins> exten
 	Item,
 	Plugins
 > {
-	constructor({ id, label }: FlatHeaderCellInit<Item, Plugins>) {
-		super({ id, label, colspan: 1 });
+	constructor({ id, label, colstart }: FlatHeaderCellInit<Item, Plugins>) {
+		super({ id, label, colspan: 1, colstart });
 	}
 
 	clone(): FlatHeaderCell<Item, Plugins> {
 		return new FlatHeaderCell({
 			id: this.id,
 			label: this.label,
+			colstart: this.colstart,
 		});
 	}
 }
@@ -94,8 +99,8 @@ export class DataHeaderCell<Item, Plugins extends AnyPlugins = AnyPlugins> exten
 > {
 	accessorKey?: keyof Item;
 	accessorFn?: (item: Item) => unknown;
-	constructor({ id, label, accessorKey, accessorFn }: DataHeaderCellInit<Item, Plugins>) {
-		super({ id, label });
+	constructor({ id, label, accessorKey, accessorFn, colstart }: DataHeaderCellInit<Item, Plugins>) {
+		super({ id, label, colstart });
 		this.accessorKey = accessorKey;
 		this.accessorFn = accessorFn;
 	}
@@ -106,6 +111,7 @@ export class DataHeaderCell<Item, Plugins extends AnyPlugins = AnyPlugins> exten
 			label: this.label,
 			accessorFn: this.accessorFn,
 			accessorKey: this.accessorKey,
+			colstart: this.colstart,
 		});
 	}
 }
@@ -121,14 +127,15 @@ export class FlatDisplayHeaderCell<
 	Item,
 	Plugins extends AnyPlugins = AnyPlugins
 > extends FlatHeaderCell<Item, Plugins> {
-	constructor({ id, label = NBSP }: FlatDisplayHeaderCellInit<Item, Plugins>) {
-		super({ id, label });
+	constructor({ id, label = NBSP, colstart }: FlatDisplayHeaderCellInit<Item, Plugins>) {
+		super({ id, label, colstart });
 	}
 
 	clone(): FlatDisplayHeaderCell<Item, Plugins> {
 		return new FlatDisplayHeaderCell({
 			id: this.id,
 			label: this.label,
+			colstart: this.colstart,
 		});
 	}
 }
@@ -148,8 +155,8 @@ export class GroupHeaderCell<Item, Plugins extends AnyPlugins = AnyPlugins> exte
 	ids: string[];
 	allId: string;
 	allIds: string[];
-	constructor({ label, colspan, ids, allIds }: GroupHeaderCellInit<Item, Plugins>) {
-		super({ id: `[${ids.join(',')}]`, label, colspan });
+	constructor({ label, ids, allIds, colspan, colstart }: GroupHeaderCellInit<Item, Plugins>) {
+		super({ id: `[${ids.join(',')}]`, label, colspan, colstart });
 		this.ids = ids;
 		this.allId = `[${allIds.join(',')}]`;
 		this.allIds = allIds;
@@ -168,9 +175,10 @@ export class GroupHeaderCell<Item, Plugins extends AnyPlugins = AnyPlugins> exte
 	clone(): GroupHeaderCell<Item, Plugins> {
 		return new GroupHeaderCell({
 			label: this.label,
-			colspan: this.colspan,
 			ids: this.ids,
 			allIds: this.allIds,
+			colspan: this.colspan,
+			colstart: this.colstart,
 		});
 	}
 }
@@ -189,19 +197,21 @@ export class GroupDisplayHeaderCell<
 > extends GroupHeaderCell<Item, Plugins> {
 	constructor({
 		label = NBSP,
-		colspan = 1,
 		ids,
 		allIds,
+		colspan = 1,
+		colstart,
 	}: GroupDisplayHeaderCellInit<Item, Plugins>) {
-		super({ label, colspan, ids, allIds });
+		super({ label, ids, allIds, colspan, colstart });
 	}
 
 	clone(): GroupDisplayHeaderCell<Item, Plugins> {
 		return new GroupDisplayHeaderCell({
 			label: this.label,
-			colspan: this.colspan,
 			ids: this.ids,
 			allIds: this.allIds,
+			colspan: this.colspan,
+			colstart: this.colstart,
 		});
 	}
 }

--- a/src/lib/headerRows.getHeaderRows.test.ts
+++ b/src/lib/headerRows.getHeaderRows.test.ts
@@ -42,16 +42,19 @@ it('arranges flat columns\n[][][]', () => {
 					label: 'First Name',
 					accessorKey: 'firstName',
 					id: 'firstName',
+					colstart: 0,
 				}),
 				new DataHeaderCell({
 					label: 'Last Name',
 					accessorKey: 'lastName',
 					id: 'lastName',
+					colstart: 1,
 				}),
 				new DataHeaderCell({
 					label: 'Age',
 					accessorKey: 'age',
 					id: 'age',
+					colstart: 2,
 				}),
 			],
 		}),
@@ -89,6 +92,7 @@ it('creates a group over flat columns\n[    ]\n[][][]', () => {
 			cells: [
 				new GroupHeaderCell({
 					colspan: 3,
+					colstart: 0,
 					label: 'Info',
 					allIds: ['firstName', 'lastName', 'age'],
 					ids: ['firstName', 'lastName', 'age'],
@@ -99,16 +103,19 @@ it('creates a group over flat columns\n[    ]\n[][][]', () => {
 			id: '1',
 			cells: [
 				new DataHeaderCell({
+					colstart: 0,
 					label: 'First Name',
 					accessorKey: 'firstName',
 					id: 'firstName',
 				}),
 				new DataHeaderCell({
+					colstart: 1,
 					label: 'Last Name',
 					accessorKey: 'lastName',
 					id: 'lastName',
 				}),
 				new DataHeaderCell({
+					colstart: 2,
 					label: 'Age',
 					accessorKey: 'age',
 					id: 'age',
@@ -162,12 +169,14 @@ it('creates two groups over different columns\n[  ][    ]\n[][][][][]', () => {
 			cells: [
 				new GroupHeaderCell({
 					colspan: 2,
+					colstart: 0,
 					label: 'Name',
 					allIds: ['firstName', 'lastName'],
 					ids: ['firstName', 'lastName'],
 				}),
 				new GroupHeaderCell({
 					colspan: 3,
+					colstart: 2,
 					label: 'Info',
 					allIds: ['age', 'status', 'progress'],
 					ids: ['age', 'status', 'progress'],
@@ -178,26 +187,31 @@ it('creates two groups over different columns\n[  ][    ]\n[][][][][]', () => {
 			id: '1',
 			cells: [
 				new DataHeaderCell({
+					colstart: 0,
 					label: 'First Name',
 					accessorKey: 'firstName',
 					id: 'firstName',
 				}),
 				new DataHeaderCell({
+					colstart: 1,
 					label: 'Last Name',
 					accessorKey: 'lastName',
 					id: 'lastName',
 				}),
 				new DataHeaderCell({
+					colstart: 2,
 					label: 'Age',
 					accessorKey: 'age',
 					id: 'age',
 				}),
 				new DataHeaderCell({
+					colstart: 3,
 					label: 'Status',
 					accessorKey: 'status',
 					id: 'status',
 				}),
 				new DataHeaderCell({
+					colstart: 4,
 					label: 'Profile Progress',
 					accessorKey: 'progress',
 					id: 'progress',
@@ -246,39 +260,45 @@ it('groups a subset of columns and ungrouped columns have flat header cells on t
 			cells: [
 				new GroupHeaderCell({
 					colspan: 2,
+					colstart: 0,
 					label: 'Name',
 					allIds: ['firstName', 'lastName'],
 					ids: ['firstName', 'lastName'],
 				}),
-				new GroupDisplayHeaderCell({ allIds: ['age'], ids: ['age'] }),
-				new GroupDisplayHeaderCell({ allIds: ['status'], ids: ['status'] }),
-				new GroupDisplayHeaderCell({ allIds: ['progress'], ids: ['progress'] }),
+				new GroupDisplayHeaderCell({ colstart: 2, allIds: ['age'], ids: ['age'] }),
+				new GroupDisplayHeaderCell({ colstart: 3, allIds: ['status'], ids: ['status'] }),
+				new GroupDisplayHeaderCell({ colstart: 4, allIds: ['progress'], ids: ['progress'] }),
 			],
 		}),
 		new HeaderRow({
 			id: '1',
 			cells: [
 				new DataHeaderCell({
+					colstart: 0,
 					label: 'First Name',
 					accessorKey: 'firstName',
 					id: 'firstName',
 				}),
 				new DataHeaderCell({
+					colstart: 1,
 					label: 'Last Name',
 					accessorKey: 'lastName',
 					id: 'lastName',
 				}),
 				new DataHeaderCell({
+					colstart: 2,
 					label: 'Age',
 					accessorKey: 'age',
 					id: 'age',
 				}),
 				new DataHeaderCell({
+					colstart: 3,
 					label: 'Status',
 					accessorKey: 'status',
 					id: 'status',
 				}),
 				new DataHeaderCell({
+					colstart: 4,
 					label: 'Profile Progress',
 					accessorKey: 'progress',
 					id: 'progress',
@@ -320,6 +340,7 @@ it('puts flat header cells on the last row if there is a gap between the group a
 			cells: [
 				new GroupHeaderCell({
 					colspan: 2,
+					colstart: 0,
 					label: 'ID',
 					allIds: ['firstName', 'progress'],
 					ids: ['firstName', 'progress'],
@@ -331,22 +352,25 @@ it('puts flat header cells on the last row if there is a gap between the group a
 			cells: [
 				new GroupHeaderCell({
 					colspan: 1,
+					colstart: 0,
 					label: 'Name',
 					allIds: ['firstName'],
 					ids: ['firstName'],
 				}),
-				new GroupDisplayHeaderCell({ ids: ['progress'], allIds: ['progress'] }),
+				new GroupDisplayHeaderCell({ colstart: 1, ids: ['progress'], allIds: ['progress'] }),
 			],
 		}),
 		new HeaderRow({
 			id: '2',
 			cells: [
 				new DataHeaderCell({
+					colstart: 0,
 					label: 'First Name',
 					accessorKey: 'firstName',
 					id: 'firstName',
 				}),
 				new DataHeaderCell({
+					colstart: 1,
 					label: 'Profile Progress',
 					accessorKey: 'progress',
 					id: 'progress',
@@ -393,11 +417,12 @@ it('puts group cells on the lowest row possible\n[]\n[][]\n[][]', () => {
 			cells: [
 				new GroupHeaderCell({
 					colspan: 1,
+					colstart: 0,
 					label: 'ID',
 					allIds: ['firstName'],
 					ids: ['firstName'],
 				}),
-				new GroupDisplayHeaderCell({ allIds: ['progress'], ids: ['progress'] }),
+				new GroupDisplayHeaderCell({ colstart: 1, allIds: ['progress'], ids: ['progress'] }),
 			],
 		}),
 		new HeaderRow({
@@ -405,12 +430,14 @@ it('puts group cells on the lowest row possible\n[]\n[][]\n[][]', () => {
 			cells: [
 				new GroupHeaderCell({
 					colspan: 1,
+					colstart: 0,
 					label: 'Name',
 					allIds: ['firstName'],
 					ids: ['firstName'],
 				}),
 				new GroupHeaderCell({
 					colspan: 1,
+					colstart: 1,
 					label: 'Info',
 					allIds: ['progress'],
 					ids: ['progress'],
@@ -421,11 +448,13 @@ it('puts group cells on the lowest row possible\n[]\n[][]\n[][]', () => {
 			id: '2',
 			cells: [
 				new DataHeaderCell({
+					colstart: 0,
 					label: 'First Name',
 					accessorKey: 'firstName',
 					id: 'firstName',
 				}),
 				new DataHeaderCell({
+					colstart: 1,
 					label: 'Profile Progress',
 					accessorKey: 'progress',
 					id: 'progress',

--- a/src/lib/headerRows.getMergedRow.test.ts
+++ b/src/lib/headerRows.getMergedRow.test.ts
@@ -15,24 +15,28 @@ it('merges two sets of group cells', () => {
 		new GroupHeaderCell<User>({
 			label: 'Name',
 			colspan: 1,
+			colstart: 0,
 			allIds: ['firstName', 'lastName'],
 			ids: ['firstName'],
 		}),
 		new GroupHeaderCell<User>({
 			label: 'Name',
 			colspan: 1,
+			colstart: 1,
 			allIds: ['firstName', 'lastName'],
 			ids: ['lastName'],
 		}),
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 2,
 			allIds: ['age', 'status'],
 			ids: ['age'],
 		}),
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 3,
 			allIds: ['age', 'status'],
 			ids: ['status'],
 		}),
@@ -44,12 +48,14 @@ it('merges two sets of group cells', () => {
 		new GroupHeaderCell<User>({
 			label: 'Name',
 			colspan: 2,
+			colstart: 0,
 			allIds: ['firstName', 'lastName'],
 			ids: ['firstName', 'lastName'],
 		}),
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 2,
+			colstart: 2,
 			allIds: ['age', 'status'],
 			ids: ['age', 'status'],
 		}),
@@ -63,17 +69,29 @@ it('merges adjacent group cells in front', () => {
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 0,
 			allIds: ['age', 'status'],
 			ids: ['age'],
 		}),
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 1,
 			allIds: ['age', 'status'],
 			ids: ['status'],
 		}),
-		new DataHeaderCell<User>({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
-		new DataHeaderCell<User>({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+		new DataHeaderCell<User>({
+			colstart: 2,
+			label: 'First Name',
+			accessorKey: 'firstName',
+			id: 'firstName',
+		}),
+		new DataHeaderCell<User>({
+			colstart: 3,
+			label: 'Last Name',
+			accessorKey: 'lastName',
+			id: 'lastName',
+		}),
 	];
 
 	const actual = getMergedRow(cells);
@@ -82,11 +100,22 @@ it('merges adjacent group cells in front', () => {
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 2,
+			colstart: 0,
 			allIds: ['age', 'status'],
 			ids: ['age', 'status'],
 		}),
-		new DataHeaderCell<User>({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
-		new DataHeaderCell<User>({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+		new DataHeaderCell<User>({
+			colstart: 2,
+			label: 'First Name',
+			accessorKey: 'firstName',
+			id: 'firstName',
+		}),
+		new DataHeaderCell<User>({
+			colstart: 3,
+			label: 'Last Name',
+			accessorKey: 'lastName',
+			id: 'lastName',
+		}),
 	];
 
 	expect(actual).toStrictEqual(expected);
@@ -94,17 +123,29 @@ it('merges adjacent group cells in front', () => {
 
 it('merges adjacent group cells behind', () => {
 	const cells = [
-		new DataHeaderCell<User>({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
-		new DataHeaderCell<User>({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+		new DataHeaderCell<User>({
+			colstart: 0,
+			label: 'First Name',
+			accessorKey: 'firstName',
+			id: 'firstName',
+		}),
+		new DataHeaderCell<User>({
+			colstart: 1,
+			label: 'Last Name',
+			accessorKey: 'lastName',
+			id: 'lastName',
+		}),
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 2,
 			allIds: ['age', 'status'],
 			ids: ['age'],
 		}),
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 3,
 			allIds: ['age', 'status'],
 			ids: ['status'],
 		}),
@@ -113,11 +154,22 @@ it('merges adjacent group cells behind', () => {
 	const actual = getMergedRow(cells);
 
 	const expected = [
-		new DataHeaderCell<User>({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
-		new DataHeaderCell<User>({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+		new DataHeaderCell<User>({
+			colstart: 0,
+			label: 'First Name',
+			accessorKey: 'firstName',
+			id: 'firstName',
+		}),
+		new DataHeaderCell<User>({
+			colstart: 1,
+			label: 'Last Name',
+			accessorKey: 'lastName',
+			id: 'lastName',
+		}),
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 2,
+			colstart: 2,
 			allIds: ['age', 'status'],
 			ids: ['age', 'status'],
 		}),
@@ -131,12 +183,24 @@ it('does not merge disjoint group cells', () => {
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 0,
 			allIds: ['age', 'status'],
 			ids: ['age'],
 		}),
-		new DataHeaderCell<User>({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
-		new DataHeaderCell<User>({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+		new DataHeaderCell<User>({
+			colstart: 1,
+			label: 'First Name',
+			accessorKey: 'firstName',
+			id: 'firstName',
+		}),
+		new DataHeaderCell<User>({
+			colstart: 2,
+			label: 'Last Name',
+			accessorKey: 'lastName',
+			id: 'lastName',
+		}),
 		new GroupHeaderCell<User>({
+			colstart: 3,
 			label: 'Info',
 			colspan: 1,
 			allIds: ['age', 'status'],
@@ -150,14 +214,26 @@ it('does not merge disjoint group cells', () => {
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 0,
 			allIds: ['age', 'status'],
 			ids: ['age'],
 		}),
-		new DataHeaderCell<User>({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
-		new DataHeaderCell<User>({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+		new DataHeaderCell<User>({
+			colstart: 1,
+			label: 'First Name',
+			accessorKey: 'firstName',
+			id: 'firstName',
+		}),
+		new DataHeaderCell<User>({
+			colstart: 2,
+			label: 'Last Name',
+			accessorKey: 'lastName',
+			id: 'lastName',
+		}),
 		new GroupHeaderCell<User>({
 			label: 'Info',
 			colspan: 1,
+			colstart: 3,
 			allIds: ['age', 'status'],
 			ids: ['status'],
 		}),

--- a/src/lib/headerRows.getOrderedColumnMatrix.test.ts
+++ b/src/lib/headerRows.getOrderedColumnMatrix.test.ts
@@ -17,27 +17,56 @@ it('orders the matrix columns', () => {
 			new GroupHeaderCell({
 				label: 'Name',
 				colspan: 1,
+				colstart: 0,
 				allIds: ['firstName', 'lastName'],
 				ids: [],
 			}),
-			new DataHeaderCell({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
+			new DataHeaderCell({
+				label: 'First Name',
+				colstart: 0,
+				accessorKey: 'firstName',
+				id: 'firstName',
+			}),
 		],
 		[
 			new GroupHeaderCell({
 				label: 'Name',
 				colspan: 1,
+				colstart: 1,
 				allIds: ['firstName', 'lastName'],
 				ids: [],
 			}),
-			new DataHeaderCell({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+			new DataHeaderCell({
+				label: 'Last Name',
+				colstart: 1,
+				accessorKey: 'lastName',
+				id: 'lastName',
+			}),
 		],
 		[
-			new GroupHeaderCell({ label: 'Info', colspan: 1, allIds: ['age', 'progress'], ids: [] }),
-			new DataHeaderCell({ label: 'Age', accessorKey: 'age', id: 'age' }),
+			new GroupHeaderCell({
+				label: 'Info',
+				colspan: 1,
+				colstart: 2,
+				allIds: ['age', 'progress'],
+				ids: [],
+			}),
+			new DataHeaderCell({ label: 'Age', colstart: 2, accessorKey: 'age', id: 'age' }),
 		],
 		[
-			new GroupHeaderCell({ label: 'Info', colspan: 1, allIds: ['age', 'progress'], ids: [] }),
-			new DataHeaderCell({ label: 'Progress', accessorKey: 'progress', id: 'progress' }),
+			new GroupHeaderCell({
+				label: 'Info',
+				colspan: 1,
+				colstart: 3,
+				allIds: ['age', 'progress'],
+				ids: [],
+			}),
+			new DataHeaderCell({
+				label: 'Progress',
+				colstart: 3,
+				accessorKey: 'progress',
+				id: 'progress',
+			}),
 		],
 	];
 
@@ -48,27 +77,56 @@ it('orders the matrix columns', () => {
 			new GroupHeaderCell({
 				label: 'Name',
 				colspan: 1,
+				colstart: 0,
 				allIds: ['firstName', 'lastName'],
 				ids: [],
 			}),
-			new DataHeaderCell({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
+			new DataHeaderCell({
+				label: 'First Name',
+				colstart: 0,
+				accessorKey: 'firstName',
+				id: 'firstName',
+			}),
 		],
 		[
-			new GroupHeaderCell({ label: 'Info', colspan: 1, allIds: ['age', 'progress'], ids: [] }),
-			new DataHeaderCell({ label: 'Age', accessorKey: 'age', id: 'age' }),
+			new GroupHeaderCell({
+				label: 'Info',
+				colspan: 1,
+				colstart: 1,
+				allIds: ['age', 'progress'],
+				ids: [],
+			}),
+			new DataHeaderCell({ label: 'Age', colstart: 1, accessorKey: 'age', id: 'age' }),
 		],
 		[
 			new GroupHeaderCell({
 				label: 'Name',
 				colspan: 1,
+				colstart: 2,
 				allIds: ['firstName', 'lastName'],
 				ids: [],
 			}),
-			new DataHeaderCell({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+			new DataHeaderCell({
+				label: 'Last Name',
+				colstart: 2,
+				accessorKey: 'lastName',
+				id: 'lastName',
+			}),
 		],
 		[
-			new GroupHeaderCell({ label: 'Info', colspan: 1, allIds: ['age', 'progress'], ids: [] }),
-			new DataHeaderCell({ label: 'Progress', accessorKey: 'progress', id: 'progress' }),
+			new GroupHeaderCell({
+				label: 'Info',
+				colspan: 1,
+				colstart: 3,
+				allIds: ['age', 'progress'],
+				ids: [],
+			}),
+			new DataHeaderCell({
+				label: 'Progress',
+				colstart: 3,
+				accessorKey: 'progress',
+				id: 'progress',
+			}),
 		],
 	];
 
@@ -81,27 +139,56 @@ it('ignores empty ordering', () => {
 			new GroupHeaderCell({
 				label: 'Name',
 				colspan: 1,
+				colstart: 0,
 				allIds: ['firstName', 'lastName'],
 				ids: [],
 			}),
-			new DataHeaderCell({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
+			new DataHeaderCell({
+				label: 'First Name',
+				colstart: 0,
+				accessorKey: 'firstName',
+				id: 'firstName',
+			}),
 		],
 		[
 			new GroupHeaderCell({
 				label: 'Name',
 				colspan: 1,
+				colstart: 1,
 				allIds: ['firstName', 'lastName'],
 				ids: [],
 			}),
-			new DataHeaderCell({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+			new DataHeaderCell({
+				label: 'Last Name',
+				colstart: 1,
+				accessorKey: 'lastName',
+				id: 'lastName',
+			}),
 		],
 		[
-			new GroupHeaderCell({ label: 'Info', colspan: 1, allIds: ['age', 'progress'], ids: [] }),
-			new DataHeaderCell({ label: 'Age', accessorKey: 'age', id: 'age' }),
+			new GroupHeaderCell({
+				label: 'Info',
+				colspan: 1,
+				colstart: 2,
+				allIds: ['age', 'progress'],
+				ids: [],
+			}),
+			new DataHeaderCell({ label: 'Age', colstart: 2, accessorKey: 'age', id: 'age' }),
 		],
 		[
-			new GroupHeaderCell({ label: 'Info', colspan: 1, allIds: ['age', 'progress'], ids: [] }),
-			new DataHeaderCell({ label: 'Progress', accessorKey: 'progress', id: 'progress' }),
+			new GroupHeaderCell({
+				label: 'Info',
+				colspan: 1,
+				colstart: 3,
+				allIds: ['age', 'progress'],
+				ids: [],
+			}),
+			new DataHeaderCell({
+				label: 'Progress',
+				colstart: 3,
+				accessorKey: 'progress',
+				id: 'progress',
+			}),
 		],
 	];
 
@@ -112,27 +199,56 @@ it('ignores empty ordering', () => {
 			new GroupHeaderCell({
 				label: 'Name',
 				colspan: 1,
+				colstart: 0,
 				allIds: ['firstName', 'lastName'],
 				ids: [],
 			}),
-			new DataHeaderCell({ label: 'First Name', accessorKey: 'firstName', id: 'firstName' }),
+			new DataHeaderCell({
+				label: 'First Name',
+				colstart: 0,
+				accessorKey: 'firstName',
+				id: 'firstName',
+			}),
 		],
 		[
 			new GroupHeaderCell({
 				label: 'Name',
 				colspan: 1,
+				colstart: 1,
 				allIds: ['firstName', 'lastName'],
 				ids: [],
 			}),
-			new DataHeaderCell({ label: 'Last Name', accessorKey: 'lastName', id: 'lastName' }),
+			new DataHeaderCell({
+				label: 'Last Name',
+				colstart: 1,
+				accessorKey: 'lastName',
+				id: 'lastName',
+			}),
 		],
 		[
-			new GroupHeaderCell({ label: 'Info', colspan: 1, allIds: ['age', 'progress'], ids: [] }),
-			new DataHeaderCell({ label: 'Age', accessorKey: 'age', id: 'age' }),
+			new GroupHeaderCell({
+				label: 'Info',
+				colspan: 1,
+				colstart: 2,
+				allIds: ['age', 'progress'],
+				ids: [],
+			}),
+			new DataHeaderCell({ label: 'Age', colstart: 2, accessorKey: 'age', id: 'age' }),
 		],
 		[
-			new GroupHeaderCell({ label: 'Info', colspan: 1, allIds: ['age', 'progress'], ids: [] }),
-			new DataHeaderCell({ label: 'Progress', accessorKey: 'progress', id: 'progress' }),
+			new GroupHeaderCell({
+				label: 'Info',
+				colspan: 1,
+				colstart: 3,
+				allIds: ['age', 'progress'],
+				ids: [],
+			}),
+			new DataHeaderCell({
+				label: 'Progress',
+				colstart: 3,
+				accessorKey: 'progress',
+				id: 'progress',
+			}),
 		],
 	];
 

--- a/src/lib/plugins/addGridLayout.ts
+++ b/src/lib/plugins/addGridLayout.ts
@@ -1,0 +1,91 @@
+import type {
+	TableAttributes,
+	TableBodyAttributes,
+	TableHeadAttributes,
+} from '$lib/createViewModel';
+import type { DeriveFn, NewTablePropSet, TablePlugin } from '$lib/types/TablePlugin';
+import { derived } from 'svelte/store';
+
+export const addGridLayout =
+	<Item>(): TablePlugin<
+		Item,
+		Record<string, never>,
+		Record<string, never>,
+		NewTablePropSet<never>
+	> =>
+	({ tableState }) => {
+		const pluginState = {};
+
+		const deriveTableAttrs: DeriveFn<TableAttributes<Item>> = (attrs) => {
+			return derived([attrs, tableState.visibleColumns], ([$attrs, $visibleColumns]) => {
+				return {
+					...$attrs,
+					style: {
+						display: 'grid',
+						'grid-template-columns': `repeat(${$visibleColumns.length}, auto)`,
+					},
+				};
+			});
+		};
+
+		const deriveTableHeadAttrs: DeriveFn<TableHeadAttributes<Item>> = (attrs) => {
+			return derived(attrs, ($attrs) => {
+				return {
+					...$attrs,
+					style: {
+						display: 'contents',
+					},
+				};
+			});
+		};
+
+		const deriveTableBodyAttrs: DeriveFn<TableBodyAttributes<Item>> = (attrs) => {
+			return derived(attrs, ($attrs) => {
+				return {
+					...$attrs,
+					style: {
+						display: 'contents',
+					},
+				};
+			});
+		};
+
+		return {
+			pluginState,
+			deriveTableAttrs,
+			deriveTableHeadAttrs,
+			deriveTableBodyAttrs,
+			hooks: {
+				'thead.tr': () => {
+					const attrs = derived([], () => {
+						return {
+							style: {
+								display: 'contents',
+							},
+						};
+					});
+					return { attrs };
+				},
+				'thead.tr.th': (cell) => {
+					const attrs = derived([], () => {
+						return {
+							style: {
+								'grid-column': `${cell.colstart + 1} / span ${cell.colspan}`,
+							},
+						};
+					});
+					return { attrs };
+				},
+				'tbody.tr': () => {
+					const attrs = derived([], () => {
+						return {
+							style: {
+								display: 'contents',
+							},
+						};
+					});
+					return { attrs };
+				},
+			},
+		};
+	};

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -8,6 +8,7 @@ export {
 } from './addColumnFilters';
 export { addColumnOrder } from './addColumnOrder';
 export { addExpandedRows } from './addExpandedRows';
+export { addGridLayout } from './addGridLayout';
 export { addGroupBy } from './addGroupBy';
 export { addHiddenColumns } from './addHiddenColumns';
 export { addPagination } from './addPagination';

--- a/src/lib/tableComponent.ts
+++ b/src/lib/tableComponent.ts
@@ -8,7 +8,7 @@ import type {
 } from './types/TablePlugin';
 import type { TableState } from './createViewModel';
 import type { Clonable } from './utils/clone';
-import { stringifyCss } from './utils/css';
+import { finalizeAttributes, mergeAttributes } from './utils/attributes';
 
 export interface TableComponentInit {
 	id: string;
@@ -25,21 +25,11 @@ export abstract class TableComponent<Item, Plugins extends AnyPlugins, Key exten
 	private attrsForName: Record<string, Readable<Record<string, unknown>>> = {};
 	attrs(): Readable<Record<string, unknown>> {
 		return derived(Object.values(this.attrsForName), ($attrsArray) => {
-			const $mergedAttrs: Record<string, unknown> = {};
-			$attrsArray.forEach(({ style, ...$attrs }) => {
-				// Handle style object.
-				if (style !== undefined && typeof style === 'object') {
-					if ($mergedAttrs.style === undefined) {
-						$mergedAttrs.style = {};
-					}
-					Object.assign($mergedAttrs.style, style);
-				}
-				Object.assign($mergedAttrs, $attrs);
+			let $mergedAttrs: Record<string, unknown> = {};
+			$attrsArray.forEach(($attrs) => {
+				$mergedAttrs = mergeAttributes($mergedAttrs, $attrs);
 			});
-			if ($mergedAttrs.style !== undefined) {
-				$mergedAttrs.style = stringifyCss($mergedAttrs.style as Record<string, unknown>);
-			}
-			return $mergedAttrs;
+			return finalizeAttributes($mergedAttrs);
 		});
 	}
 

--- a/src/lib/types/TablePlugin.ts
+++ b/src/lib/types/TablePlugin.ts
@@ -3,7 +3,12 @@ import type { BodyRow, BodyRowAttributes } from '$lib/bodyRows';
 import type { DataColumn, FlatColumn } from '$lib/columns';
 import type { HeaderCell, HeaderCellAttributes } from '$lib/headerCells';
 import type { HeaderRow, HeaderRowAttributes } from '$lib/headerRows';
-import type { PluginInitTableState } from '$lib/createViewModel';
+import type {
+	PluginInitTableState,
+	TableAttributes,
+	TableBodyAttributes,
+	TableHeadAttributes,
+} from '$lib/createViewModel';
 import type { Readable } from 'svelte/store';
 
 export type TablePlugin<
@@ -35,6 +40,9 @@ export type TablePluginInstance<
 	deriveFlatColumns?: DeriveFlatColumnsFn<Item>;
 	deriveRows?: DeriveRowsFn<Item>;
 	derivePageRows?: DeriveRowsFn<Item>;
+	deriveTableAttrs?: DeriveFn<TableAttributes<Item>>;
+	deriveTableHeadAttrs?: DeriveFn<TableHeadAttributes<Item>>;
+	deriveTableBodyAttrs?: DeriveFn<TableBodyAttributes<Item>>;
 	columnOptions?: ColumnOptions;
 	hooks?: TableHooks<Item, TablePropSet, TableAttributeSet>;
 };
@@ -62,6 +70,8 @@ export type DeriveFlatColumnsFn<Item> = <Col extends FlatColumn<Item>>(
 export type DeriveRowsFn<Item> = <Row extends BodyRow<Item>>(
 	rows: Readable<Row[]>
 ) => Readable<Row[]>;
+
+export type DeriveFn<T> = (obj: Readable<T>) => Readable<T>;
 
 export type Components<Item, Plugins extends AnyPlugins = AnyPlugins> = {
 	'thead.tr': HeaderRow<Item, Plugins>;

--- a/src/lib/utils/attributes.finalizeAttributes.test.ts
+++ b/src/lib/utils/attributes.finalizeAttributes.test.ts
@@ -1,0 +1,38 @@
+import { finalizeAttributes } from './attributes';
+
+it('ignores undefined style', () => {
+	const actual = finalizeAttributes({
+		a: 1,
+		b: 2,
+	});
+
+	const expected = { a: 1, b: 2 };
+
+	expect(actual).toStrictEqual(expected);
+});
+
+it('ignores string style', () => {
+	const actual = finalizeAttributes({
+		a: 1,
+		b: 2,
+		style: 'display:flex',
+	});
+
+	const expected = { a: 1, b: 2, style: 'display:flex' };
+
+	expect(actual).toStrictEqual(expected);
+});
+
+it('stringifies the style object', () => {
+	const actual = finalizeAttributes({
+		a: 1,
+		b: 2,
+		style: {
+			display: 'flex',
+		},
+	});
+
+	const expected = { a: 1, b: 2, style: 'display:flex' };
+
+	expect(actual).toStrictEqual(expected);
+});

--- a/src/lib/utils/attributes.mergeAttributes.test.ts
+++ b/src/lib/utils/attributes.mergeAttributes.test.ts
@@ -1,0 +1,56 @@
+import { mergeAttributes } from './attributes';
+
+it('merges basic attributes without styles', () => {
+	const actual = mergeAttributes(
+		{
+			a: 1,
+			b: 2,
+		},
+		{
+			c: 3,
+			b: 4,
+		}
+	);
+
+	const expected = {
+		a: 1,
+		b: 4,
+		c: 3,
+	};
+
+	expect(actual).toStrictEqual(expected);
+});
+
+it('merges attributes with styles', () => {
+	const actual = mergeAttributes(
+		{
+			a: 1,
+			b: 2,
+			style: {
+				a: '1',
+				b: '2',
+			},
+		},
+		{
+			c: 3,
+			b: 4,
+			style: {
+				c: '3',
+				b: '4',
+			},
+		}
+	);
+
+	const expected = {
+		a: 1,
+		b: 4,
+		c: 3,
+		style: {
+			a: '1',
+			b: '4',
+			c: '3',
+		},
+	};
+
+	expect(actual).toStrictEqual(expected);
+});

--- a/src/lib/utils/attributes.ts
+++ b/src/lib/utils/attributes.ts
@@ -1,0 +1,33 @@
+import { stringifyCss } from './css';
+
+export const mergeAttributes = <
+	T extends Record<string, unknown>,
+	U extends Record<string, unknown>
+>(
+	a: T,
+	b: U
+): T & U => {
+	if (a.style === undefined && b.style === undefined) {
+		return { ...a, ...b };
+	}
+	return {
+		...a,
+		...b,
+		style: {
+			...(typeof a.style === 'object' ? a.style : {}),
+			...(typeof b.style === 'object' ? b.style : {}),
+		},
+	};
+};
+
+export const finalizeAttributes = <T extends Record<string, unknown>>(
+	attrs: T
+): Record<string, unknown> => {
+	if (attrs.style === undefined || typeof attrs.style !== 'object') {
+		return attrs;
+	}
+	return {
+		...attrs,
+		style: stringifyCss(attrs.style as Record<string, unknown>),
+	};
+};

--- a/src/routes/alt-layouts.svelte
+++ b/src/routes/alt-layouts.svelte
@@ -15,6 +15,7 @@
 		addSubRows,
 		addGroupBy,
 		addSelectedRows,
+		addGridLayout,
 	} from '$lib/plugins';
 	import { mean, sum } from '$lib/utils/math';
 	import { getShuffled } from './_getShuffled';
@@ -54,6 +55,7 @@
 		page: addPagination({
 			initialPageSize: 20,
 		}),
+		layout: addGridLayout(),
 	});
 
 	const columns = table.createColumns([
@@ -203,8 +205,15 @@
 		}),
 	]);
 
-	const { headerRows, pageRows, tableAttrs, tableBodyAttrs, visibleColumns, pluginStates } =
-		table.createViewModel(columns);
+	const {
+		headerRows,
+		pageRows,
+		tableAttrs,
+		tableHeadAttrs,
+		tableBodyAttrs,
+		visibleColumns,
+		pluginStates,
+	} = table.createViewModel(columns);
 
 	const { groupByIds } = pluginStates.group;
 	const { sortKeys } = pluginStates.sort;
@@ -231,7 +240,7 @@
 </div>
 
 <div class="table" {...$tableAttrs}>
-	<div class="thead">
+	<div class="thead" {...$tableHeadAttrs}>
 		{#each $headerRows as headerRow (headerRow.id)}
 			<Subscribe attrs={headerRow.attrs()} let:attrs>
 				<div class="tr" {...attrs}>
@@ -269,8 +278,12 @@
 				</div>
 			</Subscribe>
 		{/each}
-		<div class="tr">
-			<div class="th" colspan={$visibleColumns.length}>
+		<div class="tr" style:display="contents">
+			<div
+				class="th"
+				colspan={$visibleColumns.length}
+				style:grid-column="1 / span {$visibleColumns.length}"
+			>
 				<input type="text" bind:value={$filterValue} placeholder="Search all data..." />
 			</div>
 		</div>

--- a/src/routes/alt-layouts.svelte
+++ b/src/routes/alt-layouts.svelte
@@ -16,6 +16,7 @@
 		addGroupBy,
 		addSelectedRows,
 		addGridLayout,
+		addResizedColumns,
 	} from '$lib/plugins';
 	import { mean, sum } from '$lib/utils/math';
 	import { getShuffled } from './_getShuffled';
@@ -55,6 +56,7 @@
 		page: addPagination({
 			initialPageSize: 20,
 		}),
+		resize: addResizedColumns(),
 		layout: addGridLayout(),
 	});
 
@@ -69,6 +71,11 @@
 					isSomeSubRowsSelected,
 				});
 			},
+			plugins: {
+				resize: {
+					disable: true,
+				},
+			},
 		}),
 		table.display({
 			id: 'expanded',
@@ -82,6 +89,11 @@
 					isAllSubRowsExpanded,
 					depth: row.depth,
 				});
+			},
+			plugins: {
+				resize: {
+					disable: true,
+				},
 			},
 		}),
 		table.column({
@@ -162,6 +174,9 @@
 					id: 'status',
 					accessor: (item) => item.status,
 					plugins: {
+						resize: {
+							disable: true,
+						},
 						sort: {
 							disable: true,
 						},
@@ -251,6 +266,7 @@
 								{...attrs}
 								on:click={props.sort.toggle}
 								class:sorted={props.sort.order !== undefined}
+								use:props.resize
 							>
 								<div>
 									<Render of={cell.render()} />
@@ -271,6 +287,9 @@
 								{/if}
 								{#if props.filter !== undefined}
 									<Render of={props.filter.render} />
+								{/if}
+								{#if !props.resize.disabled}
+									<div class="resizer" on:click|stopPropagation use:props.resize.drag />
 								{/if}
 							</div>
 						</Subscribe>
@@ -349,6 +368,21 @@
 		padding: 0.5rem;
 		border-bottom: 1px solid black;
 		border-right: 1px solid black;
+	}
+
+	.th {
+		position: relative;
+	}
+
+	.th .resizer {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		right: -4px;
+		width: 8px;
+		z-index: 1;
+		background: lightgray;
+		cursor: col-resize;
 	}
 
 	.sorted {


### PR DESCRIPTION
Closes #18.

`addRowLabel`s original intent was to allow for complex table displays. However, given the limitations of `display: table` (table layout) and the need to maintain semantic HTML, it's more appropriate to implement a plugin to convert the table to using CSS grid, then providing complex layout in markup.

By opting out of table layout, we can define rows with multiple layers of cells, notes, and annotations for example.