### PR TITLE
Fix `addResizedColumns` interaction with `addGridLayout`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelte-headless-table",
-	"version": "0.10.3",
+	"version": "0.10.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-headless-table",
-			"version": "0.10.3",
+			"version": "0.10.4",
 			"license": "MIT",
 			"dependencies": {
 				"svelte-keyed": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-headless-table",
-	"version": "0.10.3",
+	"version": "0.10.4",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",


### PR DESCRIPTION
As we support more layout options, we'll need a better way of setting the widths of columns.

Currently, addResizedColumns defines the `width`, `min-width`, and `max-width` style properties for each cell. However, we may not always want to use `width` as the basis of the column resizing.

This indicates that we need a form of information passing from the attributes of `addResizedColumns` to the attributes of `addGridLayout` i.e. `addGridLayout` should be able to read and modify the attributes defined by `addResizedColumns`.

This would close #26.