### PR TITLE
`instanceof` workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelte-headless-table",
-	"version": "0.12.2",
+	"version": "0.13.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-headless-table",
-			"version": "0.12.2",
+			"version": "0.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"svelte-keyed": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-headless-table",
-	"version": "0.12.2",
+	"version": "0.13.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/bodyCells.HeaderCell.render.test.ts
+++ b/src/lib/bodyCells.HeaderCell.render.test.ts
@@ -44,7 +44,8 @@ it('renders dynamic label with state', () => {
 		colstart: 1,
 	});
 
-	actual.injectState(state);
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	actual.injectState(state as any);
 
 	expect(actual.render()).toBe('0 columns');
 });

--- a/src/lib/bodyCells.ts
+++ b/src/lib/bodyCells.ts
@@ -1,5 +1,5 @@
 import { derived, type Readable } from 'svelte/store';
-import { DataBodyRow, type BodyRow } from './bodyRows';
+import type { BodyRow } from './bodyRows';
 import type { DataColumn, DisplayColumn, FlatColumn } from './columns';
 import { TableComponent } from './tableComponent';
 import type { DataLabel, DisplayLabel } from './types/Label';
@@ -45,7 +45,7 @@ export abstract class BodyCell<
 	}
 
 	dataRowColId(): string | undefined {
-		if (!(this.row instanceof DataBodyRow)) {
+		if (!this.row.isData()) {
 			return undefined;
 		}
 		return `${this.row.dataId}:${this.column.id}`;

--- a/src/lib/bodyCells.ts
+++ b/src/lib/bodyCells.ts
@@ -50,6 +50,16 @@ export abstract class BodyCell<
 		}
 		return `${this.row.dataId}:${this.column.id}`;
 	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isData(): this is DataBodyCell<Item, Plugins> {
+		return '__data' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isDisplay(): this is DisplayBodyCell<Item, Plugins> {
+		return '__display' in this;
+	}
 }
 
 export type DataBodyCellInit<Item, Plugins extends AnyPlugins = AnyPlugins, Value = unknown> = Omit<
@@ -71,6 +81,9 @@ export class DataBodyCell<
 	Plugins extends AnyPlugins = AnyPlugins,
 	Value = unknown
 > extends BodyCell<Item, Plugins> {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__data = true;
+
 	column: DataColumn<Item, Plugins>;
 	label?: DataLabel<Item, Plugins, Value>;
 	value: Value;
@@ -114,6 +127,9 @@ export class DisplayBodyCell<Item, Plugins extends AnyPlugins = AnyPlugins> exte
 	Item,
 	Plugins
 > {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__display = true;
+
 	column: DisplayColumn<Item, Plugins>;
 	label: DisplayLabel<Item, Plugins>;
 	constructor({ row, column, label }: DisplayBodyCellInit<Item, Plugins>) {

--- a/src/lib/bodyRows.getBodyRows.test.ts
+++ b/src/lib/bodyRows.getBodyRows.test.ts
@@ -137,7 +137,7 @@ it('transforms data for data columns', () => {
 			const cell = actual[rowIdx].cells[colIdx];
 			expect(cell).toBeInstanceOf(DataBodyCell);
 			const expectedCell = expected[rowIdx].cells[colIdx];
-			if (!(cell instanceof DataBodyCell && expectedCell instanceof DataBodyCell)) {
+			if (!(cell.isData() && expectedCell.isData())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.value).toStrictEqual(expectedCell.value);
@@ -146,7 +146,7 @@ it('transforms data for data columns', () => {
 			const cell = actual[rowIdx].cellForId[id];
 			expect(cell).toBeInstanceOf(DataBodyCell);
 			const expectedCell = expected[rowIdx].cellForId[id];
-			if (!(cell instanceof DataBodyCell && expectedCell instanceof DataBodyCell)) {
+			if (!(cell.isData() && expectedCell.isData())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.value).toStrictEqual(expectedCell.value);
@@ -237,7 +237,7 @@ it('transforms data for data columns with custom rowDataId', () => {
 			const cell = actual[rowIdx].cells[colIdx];
 			expect(cell).toBeInstanceOf(DataBodyCell);
 			const expectedCell = expected[rowIdx].cells[colIdx];
-			if (!(cell instanceof DataBodyCell && expectedCell instanceof DataBodyCell)) {
+			if (!(cell.isData() && expectedCell.isData())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.value).toStrictEqual(expectedCell.value);
@@ -246,7 +246,7 @@ it('transforms data for data columns with custom rowDataId', () => {
 			const cell = actual[rowIdx].cellForId[id];
 			expect(cell).toBeInstanceOf(DataBodyCell);
 			const expectedCell = expected[rowIdx].cellForId[id];
-			if (!(cell instanceof DataBodyCell && expectedCell instanceof DataBodyCell)) {
+			if (!(cell.isData() && expectedCell.isData())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.value).toStrictEqual(expectedCell.value);
@@ -339,7 +339,7 @@ it('transforms data with display columns', () => {
 			const cell = row.cells[colIdx];
 			expect(cell).toBeInstanceOf(DisplayBodyCell);
 			const expectedCell = expected[rowIdx].cells[colIdx];
-			if (!(cell instanceof DisplayBodyCell && expectedCell instanceof DisplayBodyCell)) {
+			if (!(cell.isDisplay() && expectedCell.isDisplay())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.label).toEqual(expectedCell.label);
@@ -348,7 +348,7 @@ it('transforms data with display columns', () => {
 			const cell = row.cellForId[id];
 			expect(cell).toBeInstanceOf(DisplayBodyCell);
 			const expectedCell = expected[rowIdx].cellForId[id];
-			if (!(cell instanceof DisplayBodyCell && expectedCell instanceof DisplayBodyCell)) {
+			if (!(cell.isDisplay() && expectedCell.isDisplay())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.label).toEqual(expectedCell.label);

--- a/src/lib/bodyRows.getBodyRows.test.ts
+++ b/src/lib/bodyRows.getBodyRows.test.ts
@@ -128,7 +128,7 @@ it('transforms data for data columns', () => {
 	[0, 1].forEach((rowIdx) => {
 		const row = actual[rowIdx];
 		expect(row).toBeInstanceOf(DataBodyRow);
-		if (!(row instanceof DataBodyRow)) {
+		if (!row.isData()) {
 			throw new Error('Incorrect BodyRow subtype');
 		}
 		expect(row.original).toStrictEqual(expected[rowIdx].original);
@@ -228,7 +228,7 @@ it('transforms data for data columns with custom rowDataId', () => {
 	[0, 1].forEach((rowIdx) => {
 		const row = actual[rowIdx];
 		expect(row).toBeInstanceOf(DataBodyRow);
-		if (!(row instanceof DataBodyRow)) {
+		if (!row.isData()) {
 			throw new Error('Incorrect BodyRow subtype');
 		}
 		expect(row.original).toStrictEqual(expected[rowIdx].original);
@@ -330,7 +330,7 @@ it('transforms data with display columns', () => {
 	[0, 1].forEach((rowIdx) => {
 		const row = actual[rowIdx];
 		expect(actual[rowIdx]).toBeInstanceOf(DataBodyRow);
-		if (!(row instanceof DataBodyRow)) {
+		if (!row.isData()) {
 			throw new Error('Incorrect BodyRow subtype');
 		}
 		expect(row.original).toStrictEqual(expected[rowIdx].original);

--- a/src/lib/bodyRows.getSubRows.test.ts
+++ b/src/lib/bodyRows.getSubRows.test.ts
@@ -84,7 +84,7 @@ it('derives the correct cells for parent with data columns', () => {
 			const cell = actual[rowIdx].cells[colIdx];
 			expect(cell).toBeInstanceOf(DataBodyCell);
 			const expectedCell = expected[rowIdx].cells[colIdx];
-			if (!(cell instanceof DataBodyCell && expectedCell instanceof DataBodyCell)) {
+			if (!(cell.isData() && expectedCell.isData())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.value).toStrictEqual(expectedCell.value);
@@ -112,7 +112,7 @@ it('derives the correct cellForId when parent has hidden cells', () => {
 			const cell = actual[rowIdx].cells[colIdx];
 			expect(cell).toBeInstanceOf(DataBodyCell);
 			const expectedCell = expected[rowIdx].cells[colIdx];
-			if (!(cell instanceof DataBodyCell && expectedCell instanceof DataBodyCell)) {
+			if (!(cell.isData() && expectedCell.isData())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.value).toStrictEqual(expectedCell.value);
@@ -121,7 +121,7 @@ it('derives the correct cellForId when parent has hidden cells', () => {
 			const cell = actual[rowIdx].cellForId[id];
 			expect(cell).toBeInstanceOf(DataBodyCell);
 			const expectedCell = expected[rowIdx].cellForId[id];
-			if (!(cell instanceof DataBodyCell && expectedCell instanceof DataBodyCell)) {
+			if (!(cell.isData() && expectedCell.isData())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.value).toStrictEqual(expectedCell.value);
@@ -163,7 +163,7 @@ it('derives the correct cells for parent with columns', () => {
 			const cell = actual[rowIdx].cells[colIdx];
 			expect(cell).toBeInstanceOf(DisplayBodyCell);
 			const expectedCell = expected[rowIdx].cells[colIdx];
-			if (!(cell instanceof DisplayBodyCell && expectedCell instanceof DisplayBodyCell)) {
+			if (!(cell.isDisplay() && expectedCell.isDisplay())) {
 				throw new Error('Incorrect instance type');
 			}
 			expect(cell.label).toEqual(expectedCell.label);

--- a/src/lib/bodyRows.getSubRows.test.ts
+++ b/src/lib/bodyRows.getSubRows.test.ts
@@ -75,7 +75,7 @@ it('derives the correct cells for parent with data columns', () => {
 	[0, 1].forEach((rowIdx) => {
 		const row = actual[rowIdx];
 		expect(row).toBeInstanceOf(DataBodyRow);
-		if (!(row instanceof DataBodyRow)) {
+		if (!row.isData()) {
 			throw new Error('Incorrect instance type');
 		}
 		expect(row.original).toStrictEqual(expected[rowIdx].original);
@@ -103,7 +103,7 @@ it('derives the correct cellForId when parent has hidden cells', () => {
 	[0, 1].forEach((rowIdx) => {
 		const row = actual[rowIdx];
 		expect(row).toBeInstanceOf(DataBodyRow);
-		if (!(row instanceof DataBodyRow)) {
+		if (!row.isData()) {
 			throw new Error('Incorrect instance type');
 		}
 		expect(row.original).toStrictEqual(expected[rowIdx].original);
@@ -154,7 +154,7 @@ it('derives the correct cells for parent with columns', () => {
 	[0, 1].forEach((rowIdx) => {
 		const row = actual[rowIdx];
 		expect(row).toBeInstanceOf(DataBodyRow);
-		if (!(row instanceof DataBodyRow)) {
+		if (!row.isData()) {
 			throw new Error('Incorrect instance type');
 		}
 		expect(row.original).toStrictEqual(expected[rowIdx].original);

--- a/src/lib/bodyRows.ts
+++ b/src/lib/bodyRows.ts
@@ -1,6 +1,6 @@
 import { derived, type Readable } from 'svelte/store';
 import { BodyCell, DataBodyCell, DisplayBodyCell } from './bodyCells';
-import { DataColumn, DisplayColumn, type FlatColumn } from './columns';
+import type { DataColumn, DisplayColumn, FlatColumn } from './columns';
 import { TableComponent } from './tableComponent';
 import type { AnyPlugins } from './types/TablePlugin';
 import { nonUndefined } from './utils/filter';
@@ -194,7 +194,7 @@ export const getBodyRows = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	});
 	data.forEach((item, rowIdx) => {
 		const cells = flatColumns.map((col) => {
-			if (col instanceof DataColumn) {
+			if (col.isData()) {
 				const dataCol = col as DataColumn<Item, Plugins>;
 				const value = dataCol.getValue(item);
 				return new DataBodyCell<Item, Plugins>({
@@ -204,7 +204,7 @@ export const getBodyRows = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 					value,
 				});
 			}
-			if (col instanceof DisplayColumn) {
+			if (col.isDisplay()) {
 				const displayCol = col as DisplayColumn<Item, Plugins>;
 				return new DisplayBodyCell<Item, Plugins>({
 					row: rows[rowIdx],
@@ -295,7 +295,7 @@ export const getSubRows = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 		const cellForId = Object.fromEntries(
 			Object.values(parentRow.cellForId).map((cell) => {
 				const { column } = cell;
-				if (column instanceof DataColumn) {
+				if (column.isData()) {
 					const dataCol = column as DataColumn<Item, Plugins>;
 					const value = dataCol.getValue(item);
 					return [
@@ -303,7 +303,7 @@ export const getSubRows = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 						new DataBodyCell({ row: subRows[rowIdx], column, label: column.cell, value }),
 					];
 				}
-				if (column instanceof DisplayColumn) {
+				if (column.isDisplay()) {
 					return [
 						column.id,
 						new DisplayBodyCell({ row: subRows[rowIdx], column, label: column.cell }),

--- a/src/lib/bodyRows.ts
+++ b/src/lib/bodyRows.ts
@@ -51,6 +51,16 @@ export abstract class BodyRow<Item, Plugins extends AnyPlugins = AnyPlugins> ext
 	}
 
 	abstract clone(props?: BodyRowCloneProps): BodyRow<Item, Plugins>;
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isData(): this is DataBodyRow<Item, Plugins> {
+		return '__data' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isDisplay(): this is DisplayBodyRow<Item, Plugins> {
+		return '__display' in this;
+	}
 }
 
 type BodyRowCloneProps = {
@@ -69,6 +79,9 @@ export class DataBodyRow<Item, Plugins extends AnyPlugins = AnyPlugins> extends 
 	Item,
 	Plugins
 > {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__data = true;
+
 	dataId: string;
 	original: Item;
 	constructor({
@@ -120,6 +133,9 @@ export class DisplayBodyRow<Item, Plugins extends AnyPlugins = AnyPlugins> exten
 	Item,
 	Plugins
 > {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__display = true;
+
 	constructor({ id, cells, cellForId, depth = 0, parentRow }: DisplayBodyRowInit<Item, Plugins>) {
 		super({ id, cells, cellForId, depth, parentRow });
 	}

--- a/src/lib/columns.ts
+++ b/src/lib/columns.ts
@@ -20,6 +20,26 @@ export class Column<Item, Plugins extends AnyPlugins = AnyPlugins> {
 		this.height = height;
 		this.plugins = plugins;
 	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isFlat(): this is FlatColumn<Item, Plugins> {
+		return '__flat' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isData(): this is DataColumn<Item, Plugins> {
+		return '__data' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isDisplay(): this is DisplayColumn<Item, Plugins> {
+		return '__display' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isGroup(): this is GroupColumn<Item, Plugins> {
+		return '__group' in this;
+	}
 }
 
 export type FlatColumnInit<
@@ -37,6 +57,9 @@ export class FlatColumn<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	Id extends string = any
 > extends Column<Item, Plugins> {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__flat = true;
+
 	id: Id;
 	constructor({ header, footer, plugins, id }: FlatColumnInit<Item, Plugins>) {
 		super({ header, footer, plugins, height: 1 });
@@ -87,6 +110,9 @@ export class DataColumn<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	Value = any
 > extends FlatColumn<Item, Plugins, Id> {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__data = true;
+
 	cell?: DataLabel<Item, Plugins, Value>;
 	accessorKey?: keyof Item;
 	accessorFn?: (item: Item) => Value;
@@ -138,6 +164,9 @@ export class DisplayColumn<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	Id extends string = any
 > extends FlatColumn<Item, Plugins, Id> {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__display = true;
+
 	cell: DisplayLabel<Item, Plugins>;
 	constructor({ header, footer, plugins, id, cell }: DisplayColumnInit<Item, Plugins, Id>) {
 		super({ header, footer, plugins, id });
@@ -156,6 +185,9 @@ export class GroupColumn<Item, Plugins extends AnyPlugins = AnyPlugins> extends 
 	Item,
 	Plugins
 > {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__group = true;
+
 	columns: Column<Item, Plugins>[];
 	ids: string[];
 	constructor({ header, footer, columns, plugins }: GroupColumnInit<Item, Plugins>) {
@@ -168,15 +200,10 @@ export class GroupColumn<Item, Plugins extends AnyPlugins = AnyPlugins> extends 
 
 export const getFlatColumnIds = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	columns: Column<Item, Plugins>[]
-): string[] =>
-	columns.flatMap((c) =>
-		c instanceof FlatColumn ? [c.id] : c instanceof GroupColumn ? c.ids : []
-	);
+): string[] => columns.flatMap((c) => (c.isFlat() ? [c.id] : c.isGroup() ? c.ids : []));
 
 export const getFlatColumns = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	columns: Column<Item, Plugins>[]
 ): FlatColumn<Item, Plugins>[] => {
-	return columns.flatMap((c) =>
-		c instanceof FlatColumn ? [c] : c instanceof GroupColumn ? getFlatColumns(c.columns) : []
-	);
+	return columns.flatMap((c) => (c.isFlat() ? [c] : c.isGroup() ? getFlatColumns(c.columns) : []));
 };

--- a/src/lib/createViewModel.ts
+++ b/src/lib/createViewModel.ts
@@ -116,7 +116,11 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 					})
 					.filter(nonUndefined)
 			);
-			return [pluginName, plugin({ pluginName, tableState: pluginInitTableState, columnOptions })];
+			return [
+				pluginName,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				plugin({ pluginName, tableState: pluginInitTableState as any, columnOptions }),
+			];
 		})
 	) as {
 		[K in keyof Plugins]: ReturnType<Plugins[K]>;
@@ -223,7 +227,8 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 
 	let rows = columnedRows;
 	deriveRowsFns.forEach((fn) => {
-		rows = fn(rows);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		rows = fn(rows as any) as any;
 	});
 
 	const injectedRows = derived(rows, ($rows) => {
@@ -258,7 +263,8 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	// Must derive from `injectedRows` instead of `rows` to ensure that `_rows` is set.
 	let pageRows = injectedRows;
 	derivePageRowsFns.forEach((fn) => {
-		pageRows = fn(pageRows);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		pageRows = fn(pageRows as any) as any;
 	});
 
 	const injectedPageRows = derived(pageRows, ($pageRows) => {

--- a/src/lib/headerCells.ts
+++ b/src/lib/headerCells.ts
@@ -38,7 +38,8 @@ export abstract class HeaderCell<
 			if (this.state === undefined) {
 				throw new Error('Missing `state` reference');
 			}
-			return this.label(this.state);
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			return this.label(this.state as any);
 		}
 		return this.label;
 	}

--- a/src/lib/headerCells.ts
+++ b/src/lib/headerCells.ts
@@ -55,6 +55,31 @@ export abstract class HeaderCell<
 	}
 
 	abstract clone(): HeaderCell<Item, Plugins>;
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isFlat(): this is FlatHeaderCell<Item, Plugins> {
+		return '__flat' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isData(): this is DataHeaderCell<Item, Plugins> {
+		return '__data' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isFlatDisplay(): this is FlatDisplayHeaderCell<Item, Plugins> {
+		return '__flat' in this && '__display' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isGroup(): this is GroupHeaderCell<Item, Plugins> {
+		return '__group' in this;
+	}
+
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	isGroupDisplay(): this is GroupDisplayHeaderCell<Item, Plugins> {
+		return '__group' in this && '__display' in this;
+	}
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -73,6 +98,9 @@ export class FlatHeaderCell<Item, Plugins extends AnyPlugins = AnyPlugins> exten
 	Item,
 	Plugins
 > {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__flat = true;
+
 	constructor({ id, label, colstart }: FlatHeaderCellInit<Item, Plugins>) {
 		super({ id, label, colspan: 1, colstart });
 	}
@@ -98,6 +126,9 @@ export class DataHeaderCell<Item, Plugins extends AnyPlugins = AnyPlugins> exten
 	Item,
 	Plugins
 > {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__data = true;
+
 	accessorKey?: keyof Item;
 	accessorFn?: (item: Item) => unknown;
 	constructor({ id, label, accessorKey, accessorFn, colstart }: DataHeaderCellInit<Item, Plugins>) {
@@ -128,6 +159,9 @@ export class FlatDisplayHeaderCell<
 	Item,
 	Plugins extends AnyPlugins = AnyPlugins
 > extends FlatHeaderCell<Item, Plugins> {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__display = true;
+
 	constructor({ id, label = NBSP, colstart }: FlatDisplayHeaderCellInit<Item, Plugins>) {
 		super({ id, label, colstart });
 	}
@@ -153,6 +187,9 @@ export class GroupHeaderCell<Item, Plugins extends AnyPlugins = AnyPlugins> exte
 	Item,
 	Plugins
 > {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__group = true;
+
 	ids: string[];
 	allId: string;
 	allIds: string[];
@@ -196,6 +233,9 @@ export class GroupDisplayHeaderCell<
 	Item,
 	Plugins extends AnyPlugins = AnyPlugins
 > extends GroupHeaderCell<Item, Plugins> {
+	// TODO Workaround for https://github.com/vitejs/vite/issues/9528
+	__display = true;
+
 	constructor({
 		label = NBSP,
 		ids,

--- a/src/lib/headerRows.ts
+++ b/src/lib/headerRows.ts
@@ -1,5 +1,5 @@
 import { derived } from 'svelte/store';
-import { DataColumn, DisplayColumn, GroupColumn, type Column } from './columns';
+import type { Column } from './columns';
 import {
 	DataHeaderCell,
 	FlatDisplayHeaderCell,
@@ -61,21 +61,22 @@ export const getHeaderRows = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	// to reduce the number of expensive transpose operations required.
 	let columnMatrix = getTransposed(rowMatrix);
 	columnMatrix = getOrderedColumnMatrix(columnMatrix, flatColumnIds);
-	populateGroupHeaderCellIds(columnMatrix);
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	populateGroupHeaderCellIds(columnMatrix as any);
 	return headerRowsForRowMatrix(getTransposed(columnMatrix));
 };
 
 export const getHeaderRowMatrix = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	columns: Column<Item, Plugins>[]
 ): Matrix<HeaderCell<Item, Plugins>> => {
-	const maxColspan = sum(columns.map((c) => (c instanceof GroupColumn ? c.ids.length : 1)));
+	const maxColspan = sum(columns.map((c) => (c.isGroup() ? c.ids.length : 1)));
 	const maxHeight = Math.max(...columns.map((c) => c.height));
 	const rowMatrix: Matrix<HeaderCell<Item, Plugins> | null> = getNullMatrix(maxColspan, maxHeight);
 	let cellOffset = 0;
 	columns.forEach((c) => {
 		const heightOffset = maxHeight - c.height;
 		loadHeaderRowMatrix(rowMatrix, c, heightOffset, cellOffset);
-		cellOffset += c instanceof GroupColumn ? c.ids.length : 1;
+		cellOffset += c.isGroup() ? c.ids.length : 1;
 	});
 	// Replace null cells with blank display cells.
 	return rowMatrix.map((cells, rowIdx) =>
@@ -95,10 +96,11 @@ const loadHeaderRowMatrix = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	rowOffset: number,
 	cellOffset: number
 ) => {
-	if (column instanceof DataColumn) {
+	if (column.isData()) {
 		// `DataHeaderCell` should always be in the last row.
 		rowMatrix[rowMatrix.length - 1][cellOffset] = new DataHeaderCell({
-			label: column.header,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			label: column.header as any,
 			accessorFn: column.accessorFn,
 			accessorKey: column.accessorKey as keyof Item,
 			id: column.id,
@@ -106,19 +108,21 @@ const loadHeaderRowMatrix = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 		});
 		return;
 	}
-	if (column instanceof DisplayColumn) {
+	if (column.isDisplay()) {
 		rowMatrix[rowMatrix.length - 1][cellOffset] = new FlatDisplayHeaderCell({
 			id: column.id,
-			label: column.header,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			label: column.header as any,
 			colstart: cellOffset,
 		});
 		return;
 	}
-	if (column instanceof GroupColumn) {
+	if (column.isGroup()) {
 		// Fill multi-colspan cells.
 		for (let i = 0; i < column.ids.length; i++) {
 			rowMatrix[rowOffset][cellOffset + i] = new GroupHeaderCell({
-				label: column.header,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				label: column.header as any,
 				colspan: 1,
 				allIds: column.ids,
 				ids: [],
@@ -128,7 +132,7 @@ const loadHeaderRowMatrix = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 		let childCellOffset = 0;
 		column.columns.forEach((c) => {
 			loadHeaderRowMatrix(rowMatrix, c, rowOffset + 1, cellOffset + childCellOffset);
-			childCellOffset += c instanceof GroupColumn ? c.ids.length : 1;
+			childCellOffset += c.isGroup() ? c.ids.length : 1;
 		});
 		return;
 	}

--- a/src/lib/headerRows.ts
+++ b/src/lib/headerRows.ts
@@ -3,7 +3,6 @@ import type { Column } from './columns';
 import {
 	DataHeaderCell,
 	FlatDisplayHeaderCell,
-	FlatHeaderCell,
 	GroupDisplayHeaderCell,
 	GroupHeaderCell,
 	type HeaderCell,
@@ -151,7 +150,7 @@ export const getOrderedColumnMatrix = <Item, Plugins extends AnyPlugins = AnyPlu
 	flatColumnIds.forEach((key, columnIdx) => {
 		const nextColumn = columnMatrix.find((columnCells) => {
 			const flatCell = columnCells[columnCells.length - 1];
-			if (!(flatCell instanceof FlatHeaderCell)) {
+			if (!flatCell.isFlat()) {
 				throw new Error('The last element of each column must be a `FlatHeaderCell`');
 			}
 			return flatCell.id === key;
@@ -172,11 +171,11 @@ export const getOrderedColumnMatrix = <Item, Plugins extends AnyPlugins = AnyPlu
 const populateGroupHeaderCellIds = <Item>(columnMatrix: Matrix<HeaderCell<Item>>) => {
 	columnMatrix.forEach((columnCells) => {
 		const lastCell = columnCells[columnCells.length - 1];
-		if (!(lastCell instanceof FlatHeaderCell)) {
+		if (!lastCell.isFlat()) {
 			throw new Error('The last element of each column must be a `FlatHeaderCell`');
 		}
 		columnCells.forEach((c) => {
-			if (c instanceof GroupHeaderCell) {
+			if (c.isGroup()) {
 				c.pushId(lastCell.id);
 			}
 		});
@@ -212,7 +211,7 @@ export const getMergedRow = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 	let endIdx = 1;
 	while (startIdx < cells.length) {
 		const cell = cells[startIdx].clone();
-		if (!(cell instanceof GroupHeaderCell)) {
+		if (!cell.isGroup()) {
 			mergedCells.push(cell);
 			startIdx++;
 			continue;
@@ -221,7 +220,7 @@ export const getMergedRow = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 		const ids: string[] = [...cell.ids];
 		while (endIdx < cells.length) {
 			const nextCell = cells[endIdx];
-			if (!(nextCell instanceof GroupHeaderCell)) {
+			if (!nextCell.isGroup()) {
 				break;
 			}
 			if (cell.allId !== nextCell.allId) {

--- a/src/lib/plugins/addColumnFilters.ts
+++ b/src/lib/plugins/addColumnFilters.ts
@@ -4,7 +4,6 @@ import type { TablePlugin, NewTablePropSet, DeriveRowsFn } from '$lib/types/Tabl
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import type { RenderConfig } from '$lib/render';
 import type { PluginInitTableState } from '$lib/createViewModel';
-import { DataHeaderCell } from '$lib/headerCells';
 import type { DataBodyCell } from '$lib/bodyCells';
 
 export interface ColumnFiltersState<Item> {
@@ -125,7 +124,7 @@ export const addColumnFilters =
 						}
 						filterValue.set(columnOption.initialFilterValue);
 						const preFilteredValues = derived(preFilteredRows, ($rows) => {
-							if (headerCell instanceof DataHeaderCell) {
+							if (headerCell.isData()) {
 								return $rows.map((row) => {
 									// TODO check and handle different BodyCell types
 									const cell = row.cellForId[headerCell.id] as DataBodyCell<Item>;
@@ -135,7 +134,7 @@ export const addColumnFilters =
 							return [];
 						});
 						const values = derived(filteredRows, ($rows) => {
-							if (headerCell instanceof DataHeaderCell) {
+							if (headerCell.isData()) {
 								return $rows.map((row) => {
 									// TODO check and handle different BodyCell types
 									const cell = row.cellForId[headerCell.id] as DataBodyCell<Item>;

--- a/src/lib/plugins/addColumnFilters.ts
+++ b/src/lib/plugins/addColumnFilters.ts
@@ -4,8 +4,8 @@ import type { TablePlugin, NewTablePropSet, DeriveRowsFn } from '$lib/types/Tabl
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import type { RenderConfig } from '$lib/render';
 import type { PluginInitTableState } from '$lib/createViewModel';
-import { DataBodyCell } from '$lib/bodyCells';
 import { DataHeaderCell } from '$lib/headerCells';
+import type { DataBodyCell } from '$lib/bodyCells';
 
 export interface ColumnFiltersState<Item> {
 	filterValues: Writable<Record<string, unknown>>;
@@ -71,7 +71,7 @@ const getFilteredRows = <Item, Row extends BodyRow<Item>>(
 			}
 			for (const [columnId, columnOption] of Object.entries(columnOptions)) {
 				const bodyCell = row.cellForId[columnId];
-				if (!(bodyCell instanceof DataBodyCell)) {
+				if (!bodyCell.isData()) {
 					continue;
 				}
 				const { value } = bodyCell;

--- a/src/lib/plugins/addDataExport.ts
+++ b/src/lib/plugins/addDataExport.ts
@@ -1,4 +1,3 @@
-import { DataBodyCell } from '$lib/bodyCells';
 import type { BodyRow } from '$lib/bodyRows';
 import type { TablePlugin } from '$lib/types/TablePlugin';
 import { derived, type Readable } from 'svelte/store';
@@ -33,7 +32,7 @@ const getObjectsFromRows = <Item>(
 		const dataObject = Object.fromEntries(
 			ids.map((id) => {
 				const cell = row.cellForId[id];
-				if (cell instanceof DataBodyCell) {
+				if (cell.isData()) {
 					return [id, cell.value];
 				}
 				return [id, null];
@@ -50,7 +49,7 @@ const getCsvFromRows = <Item>(rows: BodyRow<Item>[], ids: string[]): string => {
 	const dataLines = rows.map((row) => {
 		const line = ids.map((id) => {
 			const cell = row.cellForId[id];
-			if (cell instanceof DataBodyCell) {
+			if (cell.isData()) {
 				return cell.value;
 			}
 			return null;

--- a/src/lib/plugins/addGroupBy.ts
+++ b/src/lib/plugins/addGroupBy.ts
@@ -1,7 +1,6 @@
 import { DataBodyCell } from '$lib/bodyCells';
 import { BodyRow, DisplayBodyRow } from '$lib/bodyRows';
 import type { DataColumn } from '$lib/columns';
-import { DataHeaderCell } from '$lib/headerCells';
 import type { DataLabel } from '$lib/types/Label';
 import type { DeriveRowsFn, NewTablePropSet, TablePlugin } from '$lib/types/TablePlugin';
 import { isShiftClick } from '$lib/utils/event';
@@ -233,11 +232,11 @@ export const addGroupBy =
 			deriveRows,
 			hooks: {
 				'thead.tr.th': (cell) => {
-					const disabled = disabledGroupIds.includes(cell.id) || !(cell instanceof DataHeaderCell);
+					const disabled = disabledGroupIds.includes(cell.id) || !cell.isData();
 					const props = derived(groupByIds, ($groupByIds) => {
 						const grouped = $groupByIds.includes(cell.id);
 						const toggle = (event: Event) => {
-							if (!(cell instanceof DataHeaderCell)) return;
+							if (!cell.isData()) return;
 							if (disabled) return;
 							groupByIds.toggle(cell.id, {
 								clearOthers: disableMultiGroup || !isMultiGroupEvent(event),

--- a/src/lib/plugins/addGroupBy.ts
+++ b/src/lib/plugins/addGroupBy.ts
@@ -92,7 +92,7 @@ export const getGroupedRows = <
 	const subRowsForGroupOnValue = new Map<GroupOn, Row[]>();
 	for (const row of rows) {
 		const cell = row.cellForId[groupById];
-		if (!(cell instanceof DataBodyCell)) {
+		if (!cell.isData()) {
 			break;
 		}
 		const columnOption = columnOptions[groupById] ?? {};
@@ -130,7 +130,7 @@ export const getGroupedRows = <
 					return [id, newCell];
 				}
 				const columnCells = subRows.map((row) => row.cellForId[id]).filter(nonUndefined);
-				if (!(columnCells[0] instanceof DataBodyCell)) {
+				if (!columnCells[0].isData()) {
 					const clonedCell = columnCells[0].clone();
 					clonedCell.row = groupRow;
 					return [id, clonedCell];
@@ -164,7 +164,7 @@ export const getGroupedRows = <
 			groupCellIds,
 			allGroupByIds,
 		});
-		groupedRows.push(groupRow as Row);
+		groupedRows.push(groupRow as unknown as Row);
 		groupRow.cells.forEach((cell) => {
 			if (cell.id === groupById) {
 				groupCellIds[cell.rowColId()] = true;

--- a/src/lib/plugins/addSelectedRows.ts
+++ b/src/lib/plugins/addSelectedRows.ts
@@ -1,4 +1,4 @@
-import { DataBodyRow, type BodyRow } from '$lib/bodyRows';
+import type { BodyRow } from '$lib/bodyRows';
 import type { NewTablePropSet, TablePlugin } from '$lib/types/TablePlugin';
 import { recordSetStore, type RecordSetStore } from '$lib/utils/store';
 import { derived, type Readable, type Updater, type Writable } from 'svelte/store';
@@ -33,7 +33,7 @@ const isAllSubRowsSelectedForRow = <Item>(
 	$selectedDataIds: Record<string, boolean>,
 	linkDataSubRows: boolean
 ): boolean => {
-	if (row instanceof DataBodyRow) {
+	if (row.isData()) {
 		if (!linkDataSubRows || row.subRows === undefined) {
 			return $selectedDataIds[row.dataId] === true;
 		}
@@ -51,7 +51,7 @@ const isSomeSubRowsSelectedForRow = <Item>(
 	$selectedDataIds: Record<string, boolean>,
 	linkDataSubRows: boolean
 ): boolean => {
-	if (row instanceof DataBodyRow) {
+	if (row.isData()) {
 		if (!linkDataSubRows || row.subRows === undefined) {
 			return $selectedDataIds[row.dataId] === true;
 		}
@@ -70,7 +70,7 @@ const writeSelectedDataIds = <Item>(
 	$selectedDataIds: Record<string, boolean>,
 	linkDataSubRows: boolean
 ): void => {
-	if (row instanceof DataBodyRow) {
+	if (row.isData()) {
 		$selectedDataIds[row.dataId] = value;
 		if (!linkDataSubRows) {
 			return;
@@ -90,7 +90,7 @@ const getRowIsSelectedStore = <Item>(
 	linkDataSubRows: boolean
 ): Writable<boolean> => {
 	const { subscribe } = derived(selectedDataIds, ($selectedDataIds) => {
-		if (row instanceof DataBodyRow) {
+		if (row.isData()) {
 			if (!linkDataSubRows) {
 				return $selectedDataIds[row.dataId] === true;
 			}
@@ -105,7 +105,7 @@ const getRowIsSelectedStore = <Item>(
 			const oldValue = isAllSubRowsSelectedForRow(row, $selectedDataIds, linkDataSubRows);
 			const $updatedSelectedDataIds = { ...$selectedDataIds };
 			writeSelectedDataIds(row, fn(oldValue), $updatedSelectedDataIds, linkDataSubRows);
-			if (row.parentRow !== undefined && row.parentRow instanceof DataBodyRow) {
+			if (row.parentRow !== undefined && row.parentRow.isData()) {
 				$updatedSelectedDataIds[row.parentRow.dataId] = isAllSubRowsSelectedForRow(
 					row.parentRow,
 					$updatedSelectedDataIds,
@@ -172,10 +172,9 @@ export const addSelectedRows =
 							$selectedDataIds,
 							linkDataSubRows
 						);
-						const selected =
-							row instanceof DataBodyRow
-								? $selectedDataIds[row.dataId] === true
-								: allSubRowsSelected;
+						const selected = row.isData()
+							? $selectedDataIds[row.dataId] === true
+							: allSubRowsSelected;
 						return {
 							selected,
 							someSubRowsSelected,

--- a/src/lib/plugins/addSortBy.ts
+++ b/src/lib/plugins/addSortBy.ts
@@ -1,5 +1,5 @@
+import type { DataBodyCell } from '$lib/bodyCells';
 import type { BodyRow } from '$lib/bodyRows';
-import { DataHeaderCell } from '$lib/headerCells';
 import type { TablePlugin, NewTablePropSet, DeriveRowsFn } from '$lib/types/TablePlugin';
 import { compare } from '$lib/utils/compare';
 import { isShiftClick } from '$lib/utils/event';
@@ -194,14 +194,14 @@ export const addSortBy =
 					const props = derived(sortKeys, ($sortKeys) => {
 						const key = $sortKeys.find((k) => k.id === cell.id);
 						const toggle = (event: Event) => {
-							if (!(cell instanceof DataHeaderCell)) return;
+							if (!cell.isData()) return;
 							if (disabled) return;
 							sortKeys.toggleId(cell.id, {
 								multiSort: disableMultiSort ? false : isMultiSortEvent(event),
 							});
 						};
 						const clear = () => {
-							if (!(cell instanceof DataHeaderCell)) return;
+							if (!cell.isData()) return;
 							if (disabledSortIds.includes(cell.id)) return;
 							sortKeys.clearId(cell.id);
 						};

--- a/src/lib/plugins/addSortBy.ts
+++ b/src/lib/plugins/addSortBy.ts
@@ -1,4 +1,3 @@
-import { DataBodyCell } from '$lib/bodyCells';
 import type { BodyRow } from '$lib/bodyRows';
 import { DataHeaderCell } from '$lib/headerCells';
 import type { TablePlugin, NewTablePropSet, DeriveRowsFn } from '$lib/types/TablePlugin';
@@ -114,7 +113,7 @@ const getSortedRows = <Item, Row extends BodyRow<Item>>(
 			// Only need to check properties of `cellA` as both should have the same
 			// properties.
 			const getSortValue = columnOptions[key.id]?.getSortValue;
-			if (!(cellA instanceof DataBodyCell)) {
+			if (!cellA.isData()) {
 				return 0;
 			}
 			const valueA = cellA.value;

--- a/src/lib/plugins/addSubRows.ts
+++ b/src/lib/plugins/addSubRows.ts
@@ -41,7 +41,7 @@ export const addSubRows =
 		const deriveRows: DeriveRowsFn<Item> = (rows) => {
 			return derived(rows, ($rows) => {
 				return $rows.map((row) => {
-					if (row instanceof DataBodyRow) {
+					if (row.isData()) {
 						return withSubRows(row, getChildren);
 					}
 					return row;

--- a/src/lib/plugins/addTableFilter.ts
+++ b/src/lib/plugins/addTableFilter.ts
@@ -1,4 +1,3 @@
-import { DataBodyCell } from '$lib/bodyCells';
 import type { BodyRow } from '$lib/bodyRows';
 import type { TablePlugin, NewTablePropSet, DeriveRowsFn } from '$lib/types/TablePlugin';
 import { recordSetStore } from '$lib/utils/store';
@@ -80,7 +79,7 @@ const getFilteredRows = <Item, Row extends BodyRow<Item>>(
 				if (isHidden && !includeHiddenColumns) {
 					return false;
 				}
-				if (!(cell instanceof DataBodyCell)) {
+				if (!cell.isData()) {
 					return false;
 				}
 				let value = cell.value;


### PR DESCRIPTION
Workaround for #29 and https://github.com/vitejs/vite/issues/9528.

Replace all `instanceof` checks with `isData()`, `isFlat()`, `isDisplay()`, `isGroup()` methods.

These methods do not use `instanceof` internally but check that a meta property (`__data`, `__flat`, `__display`, `__group`) exists on the object. This can then be assigned to the instance during class construction.

This violates the open principle on components as we couple every abstract table component class to their implementations. However, we do not foresee any extensions required to the table component classes so this should be fine.

Providing the `is{X}()` methods also makes type hinting much easier, and allows users to more intuitively understand the subtypes of each table component are. It also saves the trouble of importing specific implementation classes i.e. `import { DataBodyCell } from 'svelte-headless-table'`.