### PR TITLE
Allow data exports from display columns

### DIFF
--- a/docs/src/routes/docs/[...2]api/[...3]create-columns.md
+++ b/docs/src/routes/docs/[...2]api/[...3]create-columns.md
@@ -336,3 +336,27 @@ Defines the component to use for the body cells of the display column.
 2. [`TableState`](./table-state.md),
 
 and returns a [`RenderConfig`](./--render.md#renderconfig).
+
+#### `displayDef.data: ({ column, row }, state) => Readable<unknown> | unknown`
+
+An optional method to define the underlying data of the display column cell.
+
+This is only useful when used with the [`addDataExport`](../plugins/add-data-export.md) plugin.
+
+Usually, display columns do not contain any data and are exported as `null` values. However, it may be useful to export the plugin states of each row as part of the data export.
+
+To do so, you can use the data prop to specify how the column should be exported.
+
+:::example
+
+```ts
+table.display({
+  id: 'selected',
+  ...
+  data: ({ row }, state) => {
+    return state?.pluginStates.select.getRowState(row).isSelected;
+  },
+}),
+```
+
+:::

--- a/docs/src/routes/docs/[...2]api/[...3]create-columns.md
+++ b/docs/src/routes/docs/[...2]api/[...3]create-columns.md
@@ -262,6 +262,8 @@ const columns = table.createColumns([
 </script>
 <GroupHeaderExample />
 
+:::
+
 ---
 
 ### `Table#display: (displayDef) => DisplayColumn`

--- a/docs/src/routes/docs/[...3]plugins/[...14]add-data-export.md
+++ b/docs/src/routes/docs/[...3]plugins/[...14]add-data-export.md
@@ -15,6 +15,12 @@ sidebar_title: addDataExport
 
 This is useful if you need to export data from the table with all plugin transformations applied.
 
+:::admonition type="warning"
+Display columns do not contain any data by default and will show up as `null` in the data export.
+
+If you need to add data to a display column, use the [`data`](../api/create-columns.md#displaydef-data-column-row-state-readable-unknown-unknown) property when defining the display column.
+:::
+
 ## Options
 
 :::callout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelte-headless-table",
-	"version": "0.13.3",
+	"version": "0.13.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-headless-table",
-			"version": "0.13.3",
+			"version": "0.13.4",
 			"license": "MIT",
 			"dependencies": {
 				"svelte-keyed": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "svelte-headless-table",
 	"description": "Unopinionated and extensible data tables for Svelte",
-	"version": "0.13.3",
+	"version": "0.13.4",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/columns.ts
+++ b/src/lib/columns.ts
@@ -1,3 +1,5 @@
+import type { BodyRow } from './bodyRows';
+import type { TableState } from './createViewModel';
 import type { DisplayLabel, HeaderLabel } from './types/Label';
 import type { DataLabel } from './types/Label';
 import type { AnyPlugins, PluginColumnConfigs } from './types/TablePlugin';
@@ -149,6 +151,16 @@ export class DataColumn<
 	}
 }
 
+export type DisplayColumnDataGetterProps<Item, Plugins extends AnyPlugins = AnyPlugins> = {
+	column: FlatColumn<Item, Plugins>;
+	row: BodyRow<Item, Plugins>;
+};
+
+export type DisplayColumnDataGetter<Item, Plugins extends AnyPlugins = AnyPlugins> = (
+	props: DisplayColumnDataGetterProps<Item, Plugins>,
+	state?: TableState<Item, Plugins>
+) => unknown;
+
 export type DisplayColumnInit<
 	Item,
 	Plugins extends AnyPlugins = AnyPlugins,
@@ -156,6 +168,7 @@ export type DisplayColumnInit<
 	Id extends string = any
 > = FlatColumnInit<Item, Plugins, Id> & {
 	cell: DisplayLabel<Item, Plugins>;
+	data?: DisplayColumnDataGetter<Item, Plugins>;
 };
 
 export class DisplayColumn<
@@ -168,9 +181,11 @@ export class DisplayColumn<
 	__display = true;
 
 	cell: DisplayLabel<Item, Plugins>;
-	constructor({ header, footer, plugins, id, cell }: DisplayColumnInit<Item, Plugins, Id>) {
+	data?: DisplayColumnDataGetter<Item, Plugins>;
+	constructor({ header, footer, plugins, id, cell, data }: DisplayColumnInit<Item, Plugins, Id>) {
 		super({ header, footer, plugins, id });
 		this.cell = cell;
+		this.data = data;
 	}
 }
 

--- a/src/lib/plugins/addDataExport.ts
+++ b/src/lib/plugins/addDataExport.ts
@@ -1,6 +1,7 @@
 import type { BodyRow } from '$lib/bodyRows';
 import type { TablePlugin } from '$lib/types/TablePlugin';
-import { derived, type Readable } from 'svelte/store';
+import { isReadable } from '$lib/utils/store';
+import { derived, get, type Readable } from 'svelte/store';
 
 export type DataExportFormat = 'object' | 'json' | 'csv';
 type ExportForFormat = {
@@ -35,6 +36,14 @@ const getObjectsFromRows = <Item>(
 				if (cell.isData()) {
 					return [id, cell.value];
 				}
+				if (cell.isDisplay() && cell.column.data !== undefined) {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					let data = cell.column.data({ row, column: cell.column }, row.state);
+					if (isReadable(data)) {
+						data = get(data);
+					}
+					return [id, data];
+				}
 				return [id, null];
 			})
 		);
@@ -51,6 +60,14 @@ const getCsvFromRows = <Item>(rows: BodyRow<Item>[], ids: string[]): string => {
 			const cell = row.cellForId[id];
 			if (cell.isData()) {
 				return cell.value;
+			}
+			if (cell.isDisplay() && cell.column.data !== undefined) {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				let data = cell.column.data({ row, column: cell.column }, row.state);
+				if (isReadable(data)) {
+					data = get(data);
+				}
+				return data;
 			}
 			return null;
 		});

--- a/src/lib/tableComponent.ts
+++ b/src/lib/tableComponent.ts
@@ -38,7 +38,7 @@ export abstract class TableComponent<Item, Plugins extends AnyPlugins, Key exten
 		return derivedKeys(this.propsForName) as Readable<PluginTablePropSet<Plugins>[Key]>;
 	}
 
-	protected state?: TableState<Item, Plugins>;
+	state?: TableState<Item, Plugins>;
 	injectState(state: TableState<Item, Plugins>) {
 		this.state = state;
 	}

--- a/src/lib/utils/store.ts
+++ b/src/lib/utils/store.ts
@@ -4,12 +4,12 @@ export type ReadOrWritable<T> = Readable<T> | Writable<T>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isReadable = <T>(value: any): value is Readable<T> => {
-	return value?.subscribe !== undefined;
+	return value?.subscribe instanceof Function;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isWritable = <T>(store: any): store is Writable<T> => {
-	return store?.update !== undefined && store.set !== undefined;
+	return store?.update instanceof Function && store.set instanceof Function;
 };
 
 export type WritableKeys<T> = {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -31,7 +31,7 @@
 	import { getDistinct } from '$lib/utils/array';
 	import SelectIndicator from './_SelectIndicator.svelte';
 
-	const data = readable(createSamples(50, 2));
+	const data = readable(createSamples(2, 2));
 
 	const table = createTable(data, {
 		subRows: addSubRows({
@@ -83,6 +83,9 @@
 					isSomeSubRowsSelected,
 				});
 			},
+			data: ({ row }, state) => {
+				return state?.pluginStates.select.getRowState(row).isSelected;
+			},
 			plugins: {
 				resize: {
 					disable: true,
@@ -101,6 +104,9 @@
 					isAllSubRowsExpanded,
 					depth: row.depth,
 				});
+			},
+			data: ({ row }, state) => {
+				return state?.pluginStates.expand.getRowState(row).isExpanded;
 			},
 			plugins: {
 				resize: {


### PR DESCRIPTION
Addresses #46.

Display columns can now be configured with an optional data field that allows data to be returned with `addDataExport`.