### PR TITLE
fix for undefined addResizedColumns config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "svelte-headless-table",
 	"description": "Unopinionated and extensible data tables for Svelte",
-	"version": "0.16.1",
+	"version": "0.16.2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/plugins/addResizedColumns.ts
+++ b/src/lib/plugins/addResizedColumns.ts
@@ -67,9 +67,7 @@ type ColumnsWidthState = {
 };
 
 export const addResizedColumns =
-	<Item>({
-		onResizeEnd,
-	}: AddResizedColumnsConfig={}): TablePlugin<
+	<Item>({ onResizeEnd }: AddResizedColumnsConfig = {}): TablePlugin<
 		Item,
 		ResizedColumnsState,
 		ResizedColumnsColumnOptions,

--- a/src/lib/plugins/addResizedColumns.ts
+++ b/src/lib/plugins/addResizedColumns.ts
@@ -69,7 +69,7 @@ type ColumnsWidthState = {
 export const addResizedColumns =
 	<Item>({
 		onResizeEnd,
-	}: AddResizedColumnsConfig): TablePlugin<
+	}: AddResizedColumnsConfig={}): TablePlugin<
 		Item,
 		ResizedColumnsState,
 		ResizedColumnsColumnOptions,


### PR DESCRIPTION
Fixes error if no configuration dictionary is passed to addResizedColumns.

```
	const table = createTable(data, {
		resize: addResizedColumns(),
	});
```
`TypeError: Cannot destructure property 'onResizeEnd' of 'undefined' as it is undefined.`