### PR TITLE
Basic server-side query support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3937,9 +3937,9 @@
 			"dev": true
 		},
 		"node_modules/decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
@@ -6223,9 +6223,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
@@ -11217,9 +11217,9 @@
 			"dev": true
 		},
 		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
 			"dev": true
 		},
 		"dedent": {
@@ -12954,9 +12954,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true
 		},
 		"kleur": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "svelte-headless-table",
 	"description": "Unopinionated and extensible data tables for Svelte",
-	"version": "0.16.2",
+	"version": "0.17.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/plugins/addPagination.ts
+++ b/src/lib/plugins/addPagination.ts
@@ -36,7 +36,6 @@ export const createPageStore = ({
 
 	const pageIndex = writable(initialPageIndex);
 
-	let pageCount;
 	function calcPageCount([$pageSize, $itemsCount]: [$pageSize: number, $itemsCount: number]) {
 		const $pageCount = Math.ceil($itemsCount / $pageSize);
 		pageIndex.update(($pageIndex) => {
@@ -49,6 +48,7 @@ export const createPageStore = ({
 	}
 
 	const serverItemsCount = writable(0);
+	let pageCount;
 	if (serverSide) {
 		pageCount = derived([pageSize, serverItemsCount], calcPageCount);
 	} else {

--- a/src/lib/plugins/addPagination.ts
+++ b/src/lib/plugins/addPagination.ts
@@ -33,7 +33,7 @@ export const createPageStore = ({
 		});
 	};
 	const setPageSize = (newPageSize: number) => updatePageSize(() => newPageSize);
-	
+
 	const pageIndex = writable(initialPageIndex);
 
 	let pageCount;
@@ -50,10 +50,10 @@ export const createPageStore = ({
 
 	const serverItemsCount = writable(0);
 	if (serverSide) {
-		pageCount = derived([pageSize, serverItemsCount], calcPageCount)
+		pageCount = derived([pageSize, serverItemsCount], calcPageCount);
 	} else {
-		const itemCount = derived(items, ($items) => $items.length)
-		pageCount = derived([pageSize, itemCount], calcPageCount)
+		const itemCount = derived(items, ($items) => $items.length);
+		pageCount = derived([pageSize, itemCount], calcPageCount);
 	}
 
 	const hasPreviousPage = derived(pageIndex, ($pageIndex) => {

--- a/src/lib/plugins/addPagination.ts
+++ b/src/lib/plugins/addPagination.ts
@@ -5,19 +5,26 @@ import { derived, writable, type Readable, type Updater, type Writable } from 's
 export interface PaginationConfig {
 	initialPageIndex?: number;
 	initialPageSize?: number;
+	serverSide?: boolean;
 }
 
 export interface PaginationState {
 	pageSize: Writable<number>;
 	pageIndex: Writable<number>;
 	pageCount: Readable<number>;
+	serverItemsCount: Writable<number>;
 	hasPreviousPage: Readable<boolean>;
 	hasNextPage: Readable<boolean>;
 }
 
 const MIN_PAGE_SIZE = 1;
 
-export const createPageStore = ({ items, initialPageSize, initialPageIndex }: PageStoreConfig) => {
+export const createPageStore = ({
+	items,
+	initialPageSize,
+	initialPageIndex,
+	serverSide,
+}: PageStoreConfig) => {
 	const pageSize = writable(initialPageSize);
 	const updatePageSize = (fn: Updater<number>) => {
 		pageSize.update(($pageSize) => {
@@ -26,9 +33,12 @@ export const createPageStore = ({ items, initialPageSize, initialPageIndex }: Pa
 		});
 	};
 	const setPageSize = (newPageSize: number) => updatePageSize(() => newPageSize);
+	
+	const pageIndex = writable(initialPageIndex);
 
-	const pageCount = derived([pageSize, items], ([$pageSize, $items]) => {
-		const $pageCount = Math.ceil($items.length / $pageSize);
+	let pageCount;
+	function calcPageCount([$pageSize, $itemsCount]: [$pageSize: number, $itemsCount: number]) {
+		const $pageCount = Math.ceil($itemsCount / $pageSize);
 		pageIndex.update(($pageIndex) => {
 			if ($pageCount > 0 && $pageIndex >= $pageCount) {
 				return $pageCount - 1;
@@ -36,9 +46,15 @@ export const createPageStore = ({ items, initialPageSize, initialPageIndex }: Pa
 			return $pageIndex;
 		});
 		return $pageCount;
-	});
+	}
 
-	const pageIndex = writable(initialPageIndex);
+	const serverItemsCount = writable(0);
+	if (serverSide) {
+		pageCount = derived([pageSize, serverItemsCount], calcPageCount)
+	} else {
+		const itemCount = derived(items, ($items) => $items.length)
+		pageCount = derived([pageSize, itemCount], calcPageCount)
+	}
 
 	const hasPreviousPage = derived(pageIndex, ($pageIndex) => {
 		return $pageIndex > 0;
@@ -53,8 +69,9 @@ export const createPageStore = ({ items, initialPageSize, initialPageIndex }: Pa
 			update: updatePageSize,
 			set: setPageSize,
 		},
-		pageCount,
 		pageIndex,
+		pageCount,
+		serverItemsCount,
 		hasPreviousPage,
 		hasNextPage,
 	};
@@ -64,10 +81,15 @@ export interface PageStoreConfig {
 	items: Readable<unknown[]>;
 	initialPageSize?: number;
 	initialPageIndex?: number;
+	serverSide?: boolean;
 }
 
 export const addPagination =
-	<Item>({ initialPageIndex = 0, initialPageSize = 10 }: PaginationConfig = {}): TablePlugin<
+	<Item>({
+		initialPageIndex = 0,
+		initialPageSize = 10,
+		serverSide = false,
+	}: PaginationConfig = {}): TablePlugin<
 		Item,
 		PaginationState,
 		Record<string, never>,
@@ -76,15 +98,18 @@ export const addPagination =
 	() => {
 		const prePaginatedRows = writable<BodyRow<Item>[]>([]);
 		const paginatedRows = writable<BodyRow<Item>[]>([]);
-		const { pageSize, pageCount, pageIndex, hasPreviousPage, hasNextPage } = createPageStore({
-			items: prePaginatedRows,
-			initialPageIndex,
-			initialPageSize,
-		});
+		const { pageSize, pageIndex, pageCount, serverItemsCount, hasPreviousPage, hasNextPage } =
+			createPageStore({
+				items: prePaginatedRows,
+				initialPageIndex,
+				initialPageSize,
+				serverSide,
+			});
 		const pluginState: PaginationState = {
 			pageSize,
 			pageIndex,
 			pageCount,
+			serverItemsCount,
 			hasPreviousPage,
 			hasNextPage,
 		};
@@ -92,10 +117,15 @@ export const addPagination =
 		const derivePageRows: DeriveRowsFn<Item> = (rows) => {
 			return derived([rows, pageSize, pageIndex], ([$rows, $pageSize, $pageIndex]) => {
 				prePaginatedRows.set($rows);
-				const startIdx = $pageIndex * $pageSize;
-				const _paginatedRows = $rows.slice(startIdx, startIdx + $pageSize);
-				paginatedRows.set(_paginatedRows);
-				return _paginatedRows;
+				if (!serverSide) {
+					const startIdx = $pageIndex * $pageSize;
+					const _paginatedRows = $rows.slice(startIdx, startIdx + $pageSize);
+					paginatedRows.set(_paginatedRows);
+					return _paginatedRows;
+				} else {
+					paginatedRows.set($rows);
+					return $rows;
+				}
 			});
 		};
 

--- a/src/lib/plugins/addPagination.ts
+++ b/src/lib/plugins/addPagination.ts
@@ -36,7 +36,7 @@ export const createPageStore = ({
 
 	const pageIndex = writable(initialPageIndex);
 
-	function calcPageCount([$pageSize, $itemsCount]: [$pageSize: number, $itemsCount: number]) {
+	function calcPageCountAndLimitIndex([$pageSize, $itemsCount]: [$pageSize: number, $itemsCount: number]) {
 		const $pageCount = Math.ceil($itemsCount / $pageSize);
 		pageIndex.update(($pageIndex) => {
 			if ($pageCount > 0 && $pageIndex >= $pageCount) {
@@ -50,10 +50,10 @@ export const createPageStore = ({
 	const serverItemsCount = writable(0);
 	let pageCount;
 	if (serverSide) {
-		pageCount = derived([pageSize, serverItemsCount], calcPageCount);
+		pageCount = derived([pageSize, serverItemsCount], calcPageCountAndLimitIndex);
 	} else {
 		const itemCount = derived(items, ($items) => $items.length);
-		pageCount = derived([pageSize, itemCount], calcPageCount);
+		pageCount = derived([pageSize, itemCount], calcPageCountAndLimitIndex);
 	}
 
 	const hasPreviousPage = derived(pageIndex, ($pageIndex) => {

--- a/src/lib/plugins/addSortBy.ts
+++ b/src/lib/plugins/addSortBy.ts
@@ -178,7 +178,6 @@ export const addSortBy =
 
 		const sortKeys = createSortKeysStore(initialSortKeys);
 		const preSortedRows = writable<BodyRow<Item>[]>([]);
-		//const sortedRows = writable<BodyRow<Item>[]>([]);
 
 		const deriveRows: DeriveRowsFn<Item> = (rows) => {
 			return derived([rows, sortKeys], ([$rows, $sortKeys]) => {
@@ -188,7 +187,6 @@ export const addSortBy =
 				} else {
 					return $rows;
 				}
-				//sortedRows.set(_sortedRows);
 			});
 		};
 

--- a/src/lib/plugins/addSortBy.ts
+++ b/src/lib/plugins/addSortBy.ts
@@ -10,6 +10,7 @@ export interface SortByConfig {
 	disableMultiSort?: boolean;
 	isMultiSortEvent?: (event: Event) => boolean;
 	toggleOrder?: ('asc' | 'desc' | undefined)[];
+	serverSide?: boolean;
 }
 
 const DEFAULT_TOGGLE_ORDER: ('asc' | 'desc' | undefined)[] = ['asc', 'desc', undefined];
@@ -168,6 +169,7 @@ export const addSortBy =
 		disableMultiSort = false,
 		isMultiSortEvent = isShiftClick,
 		toggleOrder,
+		serverSide = false,
 	}: SortByConfig = {}): TablePlugin<Item, SortByState<Item>, SortByColumnOptions, SortByPropSet> =>
 	({ columnOptions }) => {
 		const disabledSortIds = Object.entries(columnOptions)
@@ -176,18 +178,17 @@ export const addSortBy =
 
 		const sortKeys = createSortKeysStore(initialSortKeys);
 		const preSortedRows = writable<BodyRow<Item>[]>([]);
-		const sortedRows = writable<BodyRow<Item>[]>([]);
+		//const sortedRows = writable<BodyRow<Item>[]>([]);
 
 		const deriveRows: DeriveRowsFn<Item> = (rows) => {
 			return derived([rows, sortKeys], ([$rows, $sortKeys]) => {
 				preSortedRows.set($rows);
-				const _sortedRows = getSortedRows<Item, typeof $rows[number]>(
-					$rows,
-					$sortKeys,
-					columnOptions
-				);
-				sortedRows.set(_sortedRows);
-				return _sortedRows;
+				if (serverSide) {
+					return getSortedRows<Item, typeof $rows[number]>($rows, $sortKeys, columnOptions);
+				} else {
+					return $rows;
+				}
+				//sortedRows.set(_sortedRows);
 			});
 		};
 

--- a/src/lib/plugins/addTableFilter.ts
+++ b/src/lib/plugins/addTableFilter.ts
@@ -117,7 +117,6 @@ export const addTableFilter =
 	({ columnOptions }) => {
 		const filterValue = writable(initialFilterValue);
 		const preFilteredRows = writable<BodyRow<Item>[]>([]);
-		//const filteredRows = writable<BodyRow<Item>[]>([]);
 		const tableCellMatches = recordSetStore();
 
 		const pluginState: TableFilterState<Item> = { filterValue, preFilteredRows };
@@ -133,7 +132,6 @@ export const addTableFilter =
 					includeHiddenColumns,
 				});
 				tableCellMatches.set($tableCellMatches);
-				//filteredRows.set($filteredRows);
 				if (serverSide) {
 					return $rows;
 				} else {

--- a/src/lib/plugins/addTableFilter.ts
+++ b/src/lib/plugins/addTableFilter.ts
@@ -7,6 +7,7 @@ export interface TableFilterConfig {
 	fn?: TableFilterFn;
 	initialFilterValue?: string;
 	includeHiddenColumns?: boolean;
+	serverSide?: boolean;
 }
 
 export interface TableFilterState<Item> {
@@ -106,6 +107,7 @@ export const addTableFilter =
 		fn = textPrefixFilter,
 		initialFilterValue = '',
 		includeHiddenColumns = false,
+		serverSide = false,
 	}: TableFilterConfig = {}): TablePlugin<
 		Item,
 		TableFilterState<Item>,
@@ -115,7 +117,7 @@ export const addTableFilter =
 	({ columnOptions }) => {
 		const filterValue = writable(initialFilterValue);
 		const preFilteredRows = writable<BodyRow<Item>[]>([]);
-		const filteredRows = writable<BodyRow<Item>[]>([]);
+		//const filteredRows = writable<BodyRow<Item>[]>([]);
 		const tableCellMatches = recordSetStore();
 
 		const pluginState: TableFilterState<Item> = { filterValue, preFilteredRows };
@@ -131,8 +133,12 @@ export const addTableFilter =
 					includeHiddenColumns,
 				});
 				tableCellMatches.set($tableCellMatches);
-				filteredRows.set($filteredRows);
-				return $filteredRows;
+				//filteredRows.set($filteredRows);
+				if (serverSide) {
+					return $rows;
+				} else {
+					return $filteredRows;
+				}
 			});
 		};
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -364,6 +364,7 @@
 			groupByIds: $groupByIds,
 			sortKeys: $sortKeys,
 			filterValues: $filterValues,
+			filterValue: $filterValue,
 			selectedDataIds: $selectedDataIds,
 			columnIdOrder: $columnIdOrder,
 			hiddenColumnIds: $hiddenColumnIds,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,19 +33,25 @@
 
 	const data = readable(createSamples(2, 2));
 
+	let serverSide = false;
+
 	const table = createTable(data, {
 		subRows: addSubRows({
 			children: 'children',
 		}),
-		filter: addColumnFilters(),
+		filter: addColumnFilters({
+			serverSide: serverSide,
+		}),
 		tableFilter: addTableFilter({
 			includeHiddenColumns: true,
+			serverSide: serverSide,
 		}),
 		group: addGroupBy({
 			initialGroupByIds: [],
 		}),
 		sort: addSortBy({
 			toggleOrder: ['asc', 'desc'],
+			serverSide: serverSide,
 		}),
 		expand: addExpandedRows({
 			initialExpandedIds: { 1: true },
@@ -57,6 +63,7 @@
 		hideColumns: addHiddenColumns(),
 		page: addPagination({
 			initialPageSize: 20,
+			serverSide: serverSide,
 		}),
 		resize: addResizedColumns(),
 		export: addDataExport(),
@@ -258,7 +265,8 @@
 	const { filterValues } = pluginStates.filter;
 	const { filterValue } = pluginStates.tableFilter;
 	const { selectedDataIds } = pluginStates.select;
-	const { pageIndex, pageCount, pageSize, hasPreviousPage, hasNextPage } = pluginStates.page;
+	const { pageIndex, pageCount, pageSize, hasPreviousPage, hasNextPage, serverItemCount } =
+		pluginStates.page;
 	const { expandedIds } = pluginStates.expand;
 	const { columnIdOrder } = pluginStates.orderColumns;
 	// $: $columnIdOrder = ['expanded', ...$groupByIds];
@@ -268,6 +276,8 @@
 	const { exportedData } = pluginStates.export;
 	const { exportedData: exportedJson } = pluginStates.exportJson;
 	const { exportedData: exportedCsv } = pluginStates.exportCsv;
+
+	$serverItemCount = 6;
 </script>
 
 <h1>svelte-headless-table</h1>
@@ -373,7 +383,8 @@
 		},
 		null,
 		2
-	)}</pre>
+	)}
+serverSide: {serverSide}</pre>
 
 <style>
 	* {


### PR DESCRIPTION
Hey Bryan,

I wanted to share a very basic server side query implementation I put together.  This essentially keeps all the state storage handled by` svelte-headless-table` but disables the actual row/data mutation under the assumption that that will be handled server side.  You can then use the existing plugin props to build a server-side api search query, something like:

```javascript
const q = new URLSearchParams();

q.set('limit', String($pageSize));
q.set('order_by', $sortKeys[0].id);
q.set('dir', $sortKeys[0].order);
q.set('query', $filterValue);
q.set('page', String($pageIndex + 1));

const data = fetch(`/api_endpoint?${q}`)
```

Some thoughts:

- I added a per-plugin boolean option called "serverSide" that enables the server side functionality on only that plugin. This might make more sense as a global setting, but I could see use cases where you'd only want to enable it for certain plugins, for example if you wanted to filter on the server but still have svelte-headless-table handle pagination or sorting locally.
- I only updated `addPagination`, `addSortBy`, and `addTableFilter`, as those were what I needed for my specific project. I'm not sure what else would benefit from a `serverSide` setting, but probably `addColumnFilters` at least.
- for `addPagination`, a new store called `serverItemsCount` needs to be set to the total number of rows in the un-paginated dataset. This total count would get returned by the API server along with the server-side paginated rows.

I'm happy to make any changes you'd like, or feel free to re-write it or ignore this PR completely if you have better methods in mind. Just wanted to share in case it was useful!


Best,
Geoff