### PR TITLE
Feature / Add column width reset on dblclick

### DIFF
--- a/docs/src/routes/docs/[...3]plugins/[...12]add-resized-columns/+page.md
+++ b/docs/src/routes/docs/[...3]plugins/[...12]add-resized-columns/+page.md
@@ -113,7 +113,7 @@ Use the action on the header cell element to initialize the plugin properly.
 
 Use `drag` on a resizer element to provide drag-to-resize behaviour.
 
-```svelte {7}
+```svelte {8}
 {#each headerRow.cells as cell (cell.id)}
   <Subscribe
     attrs={cell.attrs()} let:attrs
@@ -121,6 +121,42 @@ Use `drag` on a resizer element to provide drag-to-resize behaviour.
   >
     <th {...attrs} use:props.resize>
       <div class="resizer" use:props.resize.drag />
+    </th>
+  </Subscribe>
+{/each}
+
+...
+
+<style>
+  th {
+    position: relative;
+  }
+
+  .resizer {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: -4px;
+    width: 8px;
+    background: lightgray;
+    cursor: col-resize;
+    z-index: 1;
+  }
+</style>
+```
+
+#### `reset: Action`
+
+Use `reset` on a resizer element to reset column to initial width.
+
+```svelte {8}
+{#each headerRow.cells as cell (cell.id)}
+  <Subscribe
+    attrs={cell.attrs()} let:attrs
+    props={cell.props()} let:props
+  >
+    <th {...attrs} use:props.resize>
+      <div class="resizer" use:props.resize.reset />
     </th>
   </Subscribe>
 {/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -329,7 +329,7 @@
 									<Render of={props.filter.render} />
 								{/if}
 								{#if !props.resize.disabled}
-									<div class="resizer" on:click|stopPropagation use:props.resize.drag />
+									<div class="resizer" on:click|stopPropagation use:props.resize.drag use:props.resize.reset />
 								{/if}
 							</th>
 						</Subscribe>


### PR DESCRIPTION
I tried to implement this in my project, but it was buggy, so I thought I could try to add it directly to your project. Turns out it was so much easier this way!

I added a **double click action to reset a column to its initial width**.

It also works on touchscreens by listening to `touchend` to simulate `doubletap` without interfering with the `drag` mechanism.

Feel free to tell me if I forgot something (types?) as I am not used to Svelte/Kit, NPM packages nor TypeScript.

(Actually, I tried to `package` or `build` with `pnpm` to test the bundled version, but couldn't figure out how to do... I first did the modifications directly in `js` files from `node_modules` in a project I am building, so I tested it this way instead. I'ts probably working, but you might build and test before merging just in case. Also, a **contributing guide** would be useful! - I know it might be a bit of work to make it tho...)

Nice work btw, I love working with `svelte-headless-table`! :smile: (I saw in another comment that you don't have much time to update it at the moment. I'll be happy to contribute if anything else comes to my mind while I'm working :wink:)