### PR TITLE
Add handling of null and undefined values to the SortBy plugin

### DIFF
--- a/src/lib/plugins/addSortBy.test.ts
+++ b/src/lib/plugins/addSortBy.test.ts
@@ -3,10 +3,10 @@ import { createTable } from '../createTable';
 import { addSortBy } from './addSortBy';
 
 const data = readable([
-	{ id: 1, createdAt: new Date(2023, 1, 1), name: { first: 'Ariana', last: 'Grande' } },
-	{ id: 2, createdAt: new Date(1990, 1, 1), name: { first: 'Harry', last: 'Styles' } },
-	{ id: 3, createdAt: new Date(2025, 1, 1), name: { first: 'Doja', last: 'Cat' } },
-	{ id: 4, createdAt: new Date(2010, 1, 1), name: { first: 'Sam', last: 'Smith' } },
+	{ id: 1, createdAt: new Date(2023, 1, 1), name: { first: 'Ariana', last: 'Grande' }, known: undefined },
+	{ id: 2, createdAt: new Date(1990, 1, 1), name: { first: 'Harry', last: 'Styles' }, known: 7  },
+	{ id: 3, createdAt: new Date(2025, 1, 1), name: { first: 'Doja', last: 'Cat' }, known: 21 },
+	{ id: 4, createdAt: new Date(2010, 1, 1), name: { first: 'Sam', last: 'Smith' }, known: null},
 ]);
 
 test('compare fn sort', () => {
@@ -62,4 +62,90 @@ test('descending date sort', () => {
 	const rows = get(vm.rows);
 	const rowIds = rows.map((it) => it.isData() && it.original.id);
 	expect(rowIds).toStrictEqual([3, 1, 4, 2]);
+});
+
+test('ascending nullsFirst sort', () => {
+	const table = createTable(data, {
+		sort: addSortBy({ initialSortKeys: [{ id: 'known', order: 'asc' }] }),
+	});
+	const columns = table.createColumns([
+		table.column({
+			accessor: 'known',
+			header: 'Known',
+			plugins: { 
+				sort: { 
+					handleNulls: 'nullsFirst' 
+				} 
+			}
+		}),
+	]);
+	const vm = table.createViewModel(columns);
+	const rows = get(vm.rows);
+	const rowIds = rows.map((it) => it.isData() && it.original.id);
+	expect(rowIds).toStrictEqual([1, 4, 2, 3]);
+});
+
+
+test('descending nullsFirst sort', () => {
+	const table = createTable(data, {
+		sort: addSortBy({ initialSortKeys: [{ id: 'known', order: 'desc' }] }),
+	});
+	const columns = table.createColumns([
+		table.column({
+			accessor: 'known',
+			header: 'Known',
+			plugins: { 
+				sort: { 
+					handleNulls: 'nullsFirst' 
+				} 
+			}
+		}),
+	]);
+	const vm = table.createViewModel(columns);
+	const rows = get(vm.rows);
+	const rowIds = rows.map((it) => it.isData() && it.original.id);
+	expect(rowIds).toStrictEqual([1, 4, 3, 2]);
+});
+
+test('ascending nullsLast sort', () => {
+	const table = createTable(data, {
+		sort: addSortBy({ initialSortKeys: [{ id: 'known', order: 'asc' }] }),
+	});
+	const columns = table.createColumns([
+		table.column({
+			accessor: 'known',
+			header: 'Known',
+			plugins: { 
+				sort: { 
+					handleNulls: 'nullsLast' 
+				} 
+			}
+		}),
+	]);
+	const vm = table.createViewModel(columns);
+	const rows = get(vm.rows);
+	const rowIds = rows.map((it) => it.isData() && it.original.id);
+	expect(rowIds).toStrictEqual([2, 3, 1, 4]);
+});
+
+
+test('descending nullsLast sort', () => {
+	const table = createTable(data, {
+		sort: addSortBy({ initialSortKeys: [{ id: 'known', order: 'desc' }] }),
+	});
+	const columns = table.createColumns([
+		table.column({
+			accessor: 'known',
+			header: 'Known',
+			plugins: { 
+				sort: { 
+					handleNulls: 'nullsLast' 
+				} 
+			}
+		}),
+	]);
+	const vm = table.createViewModel(columns);
+	const rows = get(vm.rows);
+	const rowIds = rows.map((it) => it.isData() && it.original.id);
+	expect(rowIds).toStrictEqual([3, 2, 1, 4]);
 });

--- a/src/lib/plugins/addSortBy.ts
+++ b/src/lib/plugins/addSortBy.ts
@@ -26,6 +26,7 @@ export interface SortByColumnOptions {
 	getSortValue?: (value: any) => string | number | (string | number)[];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	compareFn?: (left: any, right: any) => number;
+	handleNulls?: 'nullsFirst' | 'nullsLast' | undefined;
 	invert?: boolean;
 }
 
@@ -122,6 +123,7 @@ const getSortedRows = <Item, Row extends BodyRow<Item>>(
 			let order = 0;
 			const compareFn = columnOptions[key.id]?.compareFn;
 			const getSortValue = columnOptions[key.id]?.getSortValue;
+			const handleNulls = columnOptions[key.id]?.handleNulls;
 			// Only need to check properties of `cellA` as both should have the same
 			// properties.
 			if (!cellA.isData()) {
@@ -129,6 +131,26 @@ const getSortedRows = <Item, Row extends BodyRow<Item>>(
 			}
 			const valueA = cellA.value;
 			const valueB = (cellB as DataBodyCell<Item>).value;
+			//If handleNulls has been set return sort order before inverting for 'desc'
+			if (handleNulls !== undefined) {
+				if ((valueA === null || valueA === undefined) && (valueB === null || valueB === undefined)) {
+					return 0;
+				} else if (handleNulls === 'nullsFirst') {
+					if (valueA === null || valueA === undefined) {
+						return -1;
+					}
+					if (valueB === null || valueB === undefined) {
+						return 1;
+					}
+				} else if (handleNulls === 'nullsLast') {
+					if (valueA === null || valueA === undefined) {
+						return 1;
+					}
+					if (valueB === null || valueB === undefined) {
+						return -1;
+					}
+				}
+			}
 			if (compareFn !== undefined) {
 				order = compareFn(valueA, valueB);
 			} else if (getSortValue !== undefined) {


### PR DESCRIPTION
I've added functionality that allows you to push null/undefined values to the top or bottom using the sort plugin. The SortByColumnOptions has an optional enum that can take 'nullsFirst' or 'nullsLast' as a value. If no value then the sort just behaves in the regular way.

I wrote tests, but was unable to get Jest running properly in my dev environment. However, I managed to test using the src/routes/+page.svelte as suggested in. another comment.