### PR TITLE
 Fix addGridLayout bug when this plugin is combined with addHiddenColumns plugin #179

### DIFF
--- a/src/lib/plugins/addGridLayout.ts
+++ b/src/lib/plugins/addGridLayout.ts
@@ -63,14 +63,11 @@ export const addGridLayout =
 					return { attrs };
 				},
 				'thead.tr.th': (cell) => {
-					const attrs = derived([], () => {
-						return {
-							style: {
-								'grid-column': `${cell.colstart + 1} / span ${cell.colspan}`,
-							},
-						};
-					});
-					return { attrs };
+					return {
+						style: {
+							'grid-column': `${cell.colstart + 1} / span ${cell.colspan}`,
+						},
+					};
 				},
 				'tbody.tr': () => {
 					const attrs = derived([], () => {


### PR DESCRIPTION
Hi @bryanmylee , here is the path to fix https://github.com/bryanmylee/svelte-headless-table/issues/179 bug.

Best regards,  
Stéphane