### PR TITLE
New plugin : align columns !

### DIFF
--- a/src/lib/plugins/addAlignedColumns.ts
+++ b/src/lib/plugins/addAlignedColumns.ts
@@ -1,0 +1,193 @@
+import type { EventHandler } from 'svelte/elements';
+import type { HeaderCell } from '../headerCells.js';
+import type { NewTableAttributeSet, NewTablePropSet, TablePlugin } from '../types/TablePlugin.js';
+import { derived, writable, type Writable, get } from 'svelte/store';
+
+export interface AddAlignedColumnsConfig {
+	defaultAlignment?: ColumnAlignment;
+	toggleOrder?: ColumnAlignment[];
+}
+
+export interface AlignmentKey {
+	id: string;
+	alignment: ColumnAlignment;
+}
+
+const DEFAULT_TOGGLE_ORDER: ColumnAlignment[] = [null, 'left', 'center', 'right'];
+
+export type ColumnAlignmentOption = 'left' | 'right' | 'center' | null;
+
+export type ColumnAlignment =
+	| ColumnAlignmentOption
+	| {
+			head?: ColumnAlignmentOption;
+			body?: ColumnAlignmentOption;
+	  };
+
+export type AlignmentSpan = 'head' | 'body' | 'both';
+
+export type AlignedColumnsState = {
+	alignments: Writable<Record<string, ColumnAlignment | undefined>>;
+};
+
+export type AlignedColumnsColumnOptions = {
+	alignment?: ColumnAlignment;
+
+	disable?: boolean;
+};
+
+export type AlignedColumnsPropSet = NewTablePropSet<{
+	'thead.tr.th': {
+		alignment?: ColumnAlignment;
+		toggle: (node: Element) => void;
+		clear: (node: Element) => void;
+		disabled: boolean;
+	};
+	'tbody.tr.td': {
+		alignment?: ColumnAlignment;
+	};
+}>;
+
+export type AlignedColumnsAttributeSet = NewTableAttributeSet<{
+	'thead.tr.th': {
+		style?: {
+			'text-align': ColumnAlignment;
+		};
+	};
+	'tbody.tr.td': {
+		style?: { 'text-align': ColumnAlignment };
+	};
+}>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isCellDisabled = (cell: HeaderCell<any>, disabledIds: string[]) => {
+	if (disabledIds.includes(cell.id)) return true;
+	return false;
+};
+
+type ColumnsAlignmentState = Record<string, ColumnAlignment | undefined>;
+
+export const addAlignedColumns =
+	<Item>({
+		defaultAlignment,
+		toggleOrder = DEFAULT_TOGGLE_ORDER,
+	}: AddAlignedColumnsConfig = {}): TablePlugin<
+		Item,
+		AlignedColumnsState,
+		AlignedColumnsColumnOptions,
+		AlignedColumnsPropSet,
+		AlignedColumnsAttributeSet
+	> =>
+	({ columnOptions }) => {
+		const disabledAlignIds = Object.entries(columnOptions)
+			.filter(([, option]) => option.disable === true)
+			.map(([columnId]) => columnId);
+
+		const initialAlignments = Object.fromEntries(
+			Object.entries(columnOptions).map(([columnId, { alignment, disable }]) => [
+				columnId,
+				!disable ? (alignment !== undefined ? alignment : defaultAlignment) : undefined,
+			]),
+		);
+
+		const columnsAlignments = writable<ColumnsAlignmentState>(initialAlignments);
+
+		// ! `initialAlignments` follows `columnsAlignments` updates, how do i stop that ??
+		const ogAlignments = structuredClone(initialAlignments);
+
+		const pluginState: AlignedColumnsState = { alignments: columnsAlignments };
+
+		return {
+			pluginState,
+			columnOptions, // ? needed or useful ?
+			hooks: {
+				'thead.tr.th': (cell) => {
+					const onToggle = (e: Event) => {
+						e.stopPropagation();
+
+						// TODO: deal with objects
+
+						columnsAlignments.update((ca) => {
+							let currentIndex = toggleOrder.findIndex((alignment) => alignment === ca[cell.id]);
+							if (currentIndex === toggleOrder.length - 1) currentIndex = -1;
+							ca[cell.id] = toggleOrder[currentIndex + 1];
+
+							console.log('initial :', initialAlignments);
+							return ca;
+						});
+					};
+
+					const onClear = (e: Event) => {
+						e.stopPropagation();
+
+						// TODO: deal with objects
+
+						columnsAlignments.update((ca) => {
+							console.log('clear, cell :', cell.id, ca[cell.id], initialAlignments[cell.id]);
+
+							ca[cell.id] = ogAlignments[cell.id];
+							return ca;
+						});
+					};
+
+					//   const alignment = get(columnsAlignments)[cell.id];
+					const props = derived(columnsAlignments, ($columnsAlignments) => {
+						const toggle = (node: Element) => {
+							node.addEventListener('click', onToggle);
+							return {
+								destroy() {
+									node.removeEventListener('click', onToggle);
+								},
+							};
+						};
+						const clear = (node: Element) => {
+							node.addEventListener('click', onClear);
+							return {
+								destroy() {
+									node.removeEventListener('click', onClear);
+								},
+							};
+						};
+						const disabled = isCellDisabled(cell, disabledAlignIds);
+
+						return {
+							alignment: $columnsAlignments[cell.id],
+							toggle,
+							clear,
+							disabled,
+						};
+					});
+
+					const attrs = derived(columnsAlignments, ($columnsAlignment) => {
+						const alignment = $columnsAlignment[cell.id];
+
+						const alignmentStr = typeof alignment === 'string' ? alignment : alignment?.head;
+
+						return alignmentStr
+							? {
+									style: {
+										'text-align': alignmentStr,
+									},
+								}
+							: {};
+					});
+					return { props, attrs };
+				},
+				'tbody.tr.td': (cell) => {
+					const attrs = derived(columnsAlignments, ($columnsAlignment) => {
+						const alignment = $columnsAlignment[cell.id];
+						const alignmentStr = typeof alignment === 'string' ? alignment : alignment?.body;
+
+						return alignmentStr
+							? {
+									style: {
+										'text-align': alignmentStr,
+									},
+								}
+							: {};
+					});
+					return { attrs };
+				},
+			},
+		};
+	};

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -1,3 +1,4 @@
+export * from './addAlignedColumns.js';
 export * from './addColumnFilters.js';
 export * from './addColumnOrder.js';
 export * from './addDataExport.js';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,6 +19,7 @@
 		numberRangeFilter,
 		textPrefixFilter,
 		addAlignedColumns,
+		type ColumnAlignment,
 	} from '../lib/plugins/index.js';
 	import { mean, sum } from '../lib/utils/math.js';
 	import { getShuffled } from './_getShuffled.js';
@@ -37,15 +38,12 @@
 
 	let serverSide = false;
 
+	let defaultAlignment: ColumnAlignment | undefined;
+
 	const table = createTable(data, {
 		align: addAlignedColumns({
-			defaultAlignment: 'center',
-			// initialAlignments: [
-			// 	{ id: 'age', alignment: 'center' },
-			// 	{ id: 'visits', alignment: 'center' },
-			// ],
-			toggleOrder: [null, 'left', 'center', 'right'],
-			span: 'body',
+			defaultAlignment,
+			toggleOrder: ['auto', 'right'],
 		}),
 		subRows: addSubRows({
 			children: 'children',
@@ -209,6 +207,7 @@
 					plugins: {
 						align: {
 							alignment: 'right',
+							// disable: true,
 						},
 						group: {
 							getAggregateValue: (values) => mean(values),
@@ -279,7 +278,7 @@
 	const { headerRows, pageRows, tableAttrs, tableBodyAttrs, visibleColumns, pluginStates } =
 		table.createViewModel(columns);
 
-	const { alignments } = pluginStates.align;
+	const { alignments, alignDefault } = pluginStates.align;
 
 	const { groupByIds } = pluginStates.group;
 	const { sortKeys } = pluginStates.sort;
@@ -299,6 +298,27 @@
 </script>
 
 <h1>svelte-headless-table</h1>
+
+<div class="default-table-align">
+	Table default alignment :
+	<label for="rb_auto">
+		auto
+		<input type="radio" id="rb_auto" value="auto" bind:group={$alignDefault} />
+	</label>
+	<label for="rb_left">
+		left
+		<input type="radio" id="rb_left" value="left" bind:group={$alignDefault} />
+	</label>
+	<label for="rb_center">
+		center
+		<input type="radio" id="rb_center" value="center" bind:group={$alignDefault} />
+	</label>
+	<label for="rb_right">
+		right
+		<input type="radio" id="rb_right" value="right" bind:group={$alignDefault} />
+	</label>
+	(current : {$alignDefault})
+</div>
 
 <button on:click={() => ($columnIdOrder = getShuffled($columnIdOrder))}>Shuffle columns</button>
 <div>
@@ -334,11 +354,10 @@
 										⬆️
 									{/if}
 								</div>
-								{#if !props.align.disabled}
+
+								{#if !props.align.disabled && props.align.alignment !== undefined}
 									<button use:props.align.toggle>
-										{typeof props.align.alignment === 'string'
-											? props.align.alignment
-											: JSON.stringify(props.align.alignment)}
+										{props.align.alignment}
 									</button>
 									<button use:props.align.clear>x</button>
 								{/if}
@@ -404,6 +423,7 @@
 <pre>{JSON.stringify(
 		{
 			alignments: $alignments,
+			alignDefault: $alignDefault,
 			groupByIds: $groupByIds,
 			sortKeys: $sortKeys,
 			filterValues: $filterValues,
@@ -462,6 +482,11 @@ serverSide: {serverSide}</pre>
 
 	.matches {
 		font-weight: 700;
+	}
+
+	.default-table-align label {
+		padding: 0.1em 0.2em;
+		border: 1px solid currentColor;
 	}
 
 	.group {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -208,7 +208,7 @@
 					accessor: 'age',
 					plugins: {
 						align: {
-							alignment: { body: 'right' },
+							alignment: 'right',
 						},
 						group: {
 							getAggregateValue: (values) => mean(values),
@@ -248,7 +248,7 @@
 					plugins: {
 						align: {
 							alignment: 'center',
-							span: 'body',
+							alignHead: true,
 						},
 						group: {
 							getAggregateValue: (values) => sum(values),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,6 +18,7 @@
 		matchFilter,
 		numberRangeFilter,
 		textPrefixFilter,
+		addAlignedColumns,
 	} from '../lib/plugins/index.js';
 	import { mean, sum } from '../lib/utils/math.js';
 	import { getShuffled } from './_getShuffled.js';
@@ -37,6 +38,15 @@
 	let serverSide = false;
 
 	const table = createTable(data, {
+		align: addAlignedColumns({
+			defaultAlignment: 'center',
+			// initialAlignments: [
+			// 	{ id: 'age', alignment: 'center' },
+			// 	{ id: 'visits', alignment: 'center' },
+			// ],
+			toggleOrder: [null, 'left', 'center', 'right'],
+			span: 'body',
+		}),
 		subRows: addSubRows({
 			children: 'children',
 		}),
@@ -148,14 +158,14 @@
 			header: (_, { rows, pageRows }) =>
 				derived(
 					[rows, pageRows],
-					([_rows, _pageRows]) => `Name (${_rows.length} records, ${_pageRows.length} in page)`
+					([_rows, _pageRows]) => `Name (${_rows.length} records, ${_pageRows.length} in page)`,
 				),
 			columns: [
 				table.column({
 					header: (cell) => {
 						return createRender(
 							Italic,
-							derived(cell.props(), (_props) => ({ text: `First Name ${_props.sort.order}` }))
+							derived(cell.props(), (_props) => ({ text: `First Name ${_props.sort.order}` })),
 						);
 					},
 					accessor: 'firstName',
@@ -190,13 +200,16 @@
 			header: (_, { rows }) =>
 				createRender(
 					Italic,
-					derived(rows, (_rows) => ({ text: `Info (${_rows.length} samples)` }))
+					derived(rows, (_rows) => ({ text: `Info (${_rows.length} samples)` })),
 				),
 			columns: [
 				table.column({
 					header: 'Age',
 					accessor: 'age',
 					plugins: {
+						align: {
+							alignment: { body: 'right' },
+						},
 						group: {
 							getAggregateValue: (values) => mean(values),
 							cell: ({ value }) => `${(value as number).toFixed(2)} (avg)`,
@@ -233,6 +246,10 @@
 					header: 'Visits',
 					accessor: 'visits',
 					plugins: {
+						align: {
+							alignment: 'center',
+							span: 'body',
+						},
 						group: {
 							getAggregateValue: (values) => sum(values),
 							cell: ({ value }) => `${value} (total)`,
@@ -261,6 +278,8 @@
 
 	const { headerRows, pageRows, tableAttrs, tableBodyAttrs, visibleColumns, pluginStates } =
 		table.createViewModel(columns);
+
+	const { alignments } = pluginStates.align;
 
 	const { groupByIds } = pluginStates.group;
 	const { sortKeys } = pluginStates.sort;
@@ -315,6 +334,14 @@
 										⬆️
 									{/if}
 								</div>
+								{#if !props.align.disabled}
+									<button use:props.align.toggle>
+										{typeof props.align.alignment === 'string'
+											? props.align.alignment
+											: JSON.stringify(props.align.alignment)}
+									</button>
+									<button use:props.align.clear>x</button>
+								{/if}
 								{#if !props.group.disabled}
 									<button on:click|stopPropagation={props.group.toggle}>
 										{#if props.group.grouped}
@@ -376,6 +403,7 @@
 
 <pre>{JSON.stringify(
 		{
+			alignments: $alignments,
 			groupByIds: $groupByIds,
 			sortKeys: $sortKeys,
 			filterValues: $filterValues,
@@ -387,7 +415,7 @@
 			columnWidths: $columnWidths,
 		},
 		null,
-		2
+		2,
 	)}
 serverSide: {serverSide}</pre>
 


### PR DESCRIPTION
Added a plugin to manage columns alignment.

I think I found a neat API and behavior, but it's not final as-is. I'm open to suggestions, and would also need to create the docs accordingly.

## How it works

Simply apply `text-align: ${alignment}` to cells.

### Table Options

#### Default Alignment

Set default alignment for table. Columns without `alignment` property will use the default if not `disabled`.

#### Toggle Order

Set alignment order.

A final column toggle order will be [ columnOptions.alignment, ...toggleOrder ];

### Column Options

#### Alignment

Initial column alignment.

#### Align Head

Does the `th` align? If not, only `td` cells align.

#### Disable

Disable alignment completely for the moment.

**I'd like this option to disable toggling only, while allowing to set an initial value.**

## Usage

```svelte
<script>
let defaultAlignment: ColumnAlignment | undefined;

const table = createTable(data, {
  align: addAlignedColumns({
	  defaultAlignment,
	  toggleOrder: ['auto', 'right']
  }),
  // ...
});

const columns = table.createColumns([
  table.column({
    header: 'Data',
    accessor: 'data',
    plugins: {
    align: {
      alignment: 'right',
      // alignHead: false,
      // disable: false
    }
  }
]);
</script>

<!-- table -->

<!-- thead tr -->
  <th {...attrs}>
    {#if !props.align.disabled && props.align.alignment !== undefined}
      <button use:props.align.toggle>
        {props.align.alignment}
      </button>
      <button use:props.align.clear>x</button>
    {/if}
  </th>

<!-- tbody tr-->
  <td {...attrs}>
    <!-- td content -->
  </th>
  ```