### PR TITLE
Update `createColumns()` doc

### DIFF
--- a/docs/src/routes/docs/[...2]api/[...3]create-columns/+page.md
+++ b/docs/src/routes/docs/[...2]api/[...3]create-columns/+page.md
@@ -85,6 +85,13 @@ Defines the id of the data column. **Duplicate ids are not allowed** on a single
 
 _Defaults to the value of `accessor` if a string accessor is passed. If a function accessor is passed, defaults to the value of `header` instead_.
 
+
+:::admonition type="tip"
+
+The `id` will be parsed with [`svelte-keyed`](https://github.com/bryanmylee/svelte-keyed), so make sure to format it without dot notation (`object.prop`) or array notation (`object[0]`).
+
+:::
+
 #### `columnDef.header: RenderConfig | ((headerCell, state) => RenderConfig)`
 
 Defines the component to use for the header cell of the data column.

--- a/docs/src/routes/docs/[...2]api/[...3]create-columns/+page.md
+++ b/docs/src/routes/docs/[...2]api/[...3]create-columns/+page.md
@@ -81,16 +81,15 @@ const columns = table.createColumns([
 
 #### `columnDef.id?: string`
 
-Defines the id of the data column. **Duplicate ids are not allowed** on a single table.
-
-_Defaults to the value of `accessor` if a string accessor is passed. If a function accessor is passed, defaults to the value of `header` instead_.
-
-
-:::admonition type="tip"
+:::admonition type="warning"
 
 The `id` will be parsed with [`svelte-keyed`](https://github.com/bryanmylee/svelte-keyed), so make sure to format it without dot notation (`object.prop`) or array notation (`object[0]`).
 
 :::
+
+Defines the id of the data column. **Duplicate ids are not allowed** on a single table.
+
+_Defaults to the value of `accessor` if a string accessor is passed. If a function accessor is passed, defaults to the value of `header` instead_.
 
 #### `columnDef.header: RenderConfig | ((headerCell, state) => RenderConfig)`
 


### PR DESCRIPTION
Added warning to avoid formatting `id` so that `svelte-keyed` will not parse it wrongly.

I added it as `tip` but was wondering is a `warning` would be better since it fails to execute.

***

It gave me an error while I used `column_id[x]` in a for loop to generate columns.

>TypeError: Cannot set properties of undefined (setting '0')

Here's the full call stack :

```
TypeError: Cannot set properties of undefined (setting '0')
    at /home/gugul/DEV/CRCATNQ/sveltekit-demo/node_modules/.pnpm/svelte-keyed@2.0.0_svelte@4.2.11/node_modules/svelte-keyed/dist/index.js:40:59
    at Object.update (/home/gugul/DEV/CRCATNQ/sveltekit-demo/node_modules/.pnpm/svelte@4.2.11/node_modules/svelte/src/runtime/store/index.js:69:7)
    at Object.set (/home/gugul/DEV/CRCATNQ/sveltekit-demo/node_modules/.pnpm/svelte-keyed@2.0.0_svelte@4.2.11/node_modules/svelte-keyed/dist/index.js:35:16)
    at /home/gugul/DEV/CRCATNQ/sveltekit-demo/node_modules/.pnpm/svelte-headless-table@0.18.2_svelte@4.2.11/node_modules/svelte-headless-table/dist/plugins/addColumnFilters.js:67:33
...
```