### PR TITLE
docs: Fixes two incorrect links for addSubRows and addGroupBy plugins.

### DIFF
--- a/docs/src/routes/docs/[...2]api/[...12]body-row/+page.md
+++ b/docs/src/routes/docs/[...2]api/[...12]body-row/+page.md
@@ -67,8 +67,8 @@ The sub rows of the current row if it exists. `undefined` if this row has no sub
 
 By default, the following plugins can define sub-rows:
 
-- [addSubRows](../plugins/add-sub-rows.md)
-- [addGroupBy](../plugins/add-group-by.md)
+- [addSubRows](../../plugins/add-sub-rows.md)
+- [addGroupBy](../../plugins/add-group-by.md)
 
 ### `isData: () => boolean`
 


### PR DESCRIPTION
This PR fixes two incorrect links for addSubRows and addGroupBy plugins on the BodyRow API page.