### PR TITLE
Fix randomly selected rows #164

### DIFF
--- a/src/lib/plugins/addSubRows.ts
+++ b/src/lib/plugins/addSubRows.ts
@@ -35,8 +35,17 @@ export const addSubRows =
 		NewTablePropSet<never>
 	> =>
 	() => {
-		const getChildren: ValidChildrenFn<Item> =
-			children instanceof Function ? children : (item) => item[children] as unknown as Item[];
+		let getChildren: ValidChildrenFn<Item>;
+		if (children instanceof Function) {
+			getChildren = children;
+		} else {
+			getChildren = (item) => {
+				const unknownVal = item[children];
+				return unknownVal instanceof Array && unknownVal.length > 0
+					? (unknownVal as unknown as Item[])
+					: undefined;
+			};
+		}
 
 		const deriveRows: DeriveRowsFn<Item> = (rows) => {
 			return derived(rows, ($rows) => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,7 +32,7 @@
 	import { getDistinct } from '../lib/utils/array.js';
 	import SelectIndicator from './_SelectIndicator.svelte';
 
-	const data = readable(createSamples(2, 2));
+	const data = readable(createSamples(5, 2));
 
 	let serverSide = false;
 

--- a/src/routes/_createSamples.ts
+++ b/src/routes/_createSamples.ts
@@ -16,7 +16,9 @@ export const createSamples = (...lengths: number[]) => {
 		return [...Array(length)].map(() => {
 			return {
 				...getSample(),
-				...(lengths[depth + 1] !== undefined ? { children: createSamplesLevel(depth + 1) } : {}),
+				...(lengths[depth + 1] !== undefined && Math.random() >= 0.25
+					? { children: createSamplesLevel(depth + 1) }
+					: { children: [] }),
 			};
 		});
 	};


### PR DESCRIPTION
Fixes #164. Issue occurs when children string property is an empty array.

Updated `createSamples` to randomly exclude children. 

## TODO
- [ ] Create tests
