### PR TITLE
Fix type issue with creation of LabelHeader

### DIFF
--- a/src/lib/types/Label.ts
+++ b/src/lib/types/Label.ts
@@ -19,4 +19,4 @@ export type DisplayLabel<Item, Plugins extends AnyPlugins = AnyPlugins> = (
 // inferred for subtypes.
 export type HeaderLabel<Item, Plugins extends AnyPlugins = AnyPlugins> =
 	| RenderConfig
-	| ((cell: HeaderCell<Item>, state: TableState<Item, Plugins>) => RenderConfig);
+	| ((cell: HeaderCell<Item, Plugins>, state: TableState<Item, Plugins>) => RenderConfig);


### PR DESCRIPTION
Missing generic declaration in HeaderCell type creates typescript error when doing the following:

```typescript
export function createDataTableHeaderCell<Item>(): HeaderLabel<Item, TablePlugins<Item>> {
    return (cell: HeaderCell<Item, TablePlugins<Item>>) =>
      createRender(MyHeaderCellComponent<Item>, {
        props: cell.props(),
      });
  }
  ```
  
  ==> 
  ```
  Type '(cell: HeaderCell<Item, TablePlugins<Item>>) => ComponentRenderConfig<DataTableHeaderCell<Item>>' is not assignable to type 'HeaderLabel<Item, TablePlugins<Item>>'.
  ```